### PR TITLE
Fix tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andes/plex",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/andes/plex.git"

--- a/src/lib/tooltip/tooltip.component.ts
+++ b/src/lib/tooltip/tooltip.component.ts
@@ -4,7 +4,7 @@ import { TooltipContentComponent } from './tooltip-content.component';
 
 @Directive({
     // tslint:disable-next-line:directive-selector
-    selector: '[title]'
+    selector: '[tooltip]'
 })
 // tslint:disable-next-line:directive-class-suffix
 export class TooltipComponent {
@@ -20,7 +20,7 @@ export class TooltipComponent {
     // -------------------------------------------------------------------------
 
     // tslint:disable-next-line:no-input-rename
-    @Input('title') content: string | TooltipContentComponent;
+    @Input('tooltip') content: string | TooltipContentComponent;
     @Input() titlePosition: 'top' | 'bottom' | 'left' | 'right' = 'top';
     @Input() tooltipDisabled: boolean;
     @Input() tooltipAnimation = false;


### PR DESCRIPTION
- Cambiamos el nombre del selector en tooltip component para evitar el "doble tooltip"

- ### ** Luego de publicar esta versión de plex es necesario mergear la rama fixesUI a develop**
