### PR TITLE
Comparación de hora en plex-datetime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andes/plex",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/andes/plex.git"

--- a/src/demo/app/datetime/datetime.component.ts
+++ b/src/demo/app/datetime/datetime.component.ts
@@ -31,6 +31,6 @@ export class DateTimeDemoComponent implements OnInit {
     }
 
     updateMaxHora() {
-        this.tModel.maxHora = moment().add(180, 'minutes');
+        this.tModel.minHora = moment().add(30, 'minutes').add(1, 'days');
     }
 }

--- a/src/demo/app/home/home.component.ts
+++ b/src/demo/app/home/home.component.ts
@@ -5,10 +5,11 @@ import { Plex } from '../../../lib/core/service';
     templateUrl: 'home.html'
 })
 export class HomeDemoComponent {
-    // Permite el uso de flex-box en el componente
     public field = '';
-    constructor(public plex: Plex) {}
-    guardar($event) {
+    public tooltip = 'Este es un tooltip<br>multilinea que ocupa mucho espacio';
 
+    constructor(public plex: Plex) { }
+
+    guardar($event) {
     }
 }

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -1,7 +1,7 @@
 <plex-layout main="8">
   <plex-layout-main>
       <header>
-          <div class="page-title" title="Esta es la clase page-title" titlePosition="right">Gestor de agendas</div>
+          <div class="page-title" [title]="tooltip" titlePosition="right">Gestor de agendas</div>
       </header>
       <ul class="list-group">
           <li class="list-group-item active">Cras justo odio</li>

--- a/src/lib/core/validator.functions.ts
+++ b/src/lib/core/validator.functions.ts
@@ -78,6 +78,12 @@ export function dateValidator(type: string, min: any, max: any) {
             // Controla min
             if (min !== undefined && min !== null && min !== '') {
                 min = moment(min).toDate();
+                // Igualamos las fechas para solor comparar hora y minutos
+                if (this.type === 'time') {
+                    min.setFullYear(value.getFullYear());
+                    min.setMonth(value.getMonth());
+                    min.setDate(value.getDate());
+                }
                 if (value < min) {
                     return {
                         min: {
@@ -87,10 +93,15 @@ export function dateValidator(type: string, min: any, max: any) {
                     };
                 }
             }
-
             // Controla max
             if (max !== undefined && max !== null && max !== '') {
                 max = moment(max).toDate();
+                // Igualamos las fechas para solor comparar hora y minutos
+                if (this.type === 'time') {
+                    max.setFullYear(value.getFullYear());
+                    max.setMonth(value.getMonth());
+                    max.setDate(value.getDate());
+                }
                 if (value > max) {
                     return {
                         max: {

--- a/src/lib/tooltip/tooltip-content.component.ts
+++ b/src/lib/tooltip/tooltip-content.component.ts
@@ -9,7 +9,7 @@ import { Component, Input, AfterViewInit, ElementRef, ChangeDetectorRef } from '
                 role="tooltip">
                 <div class="tooltip-inner">
                     <ng-content></ng-content>
-                    {{ content }}
+                    <div [innerHTML]="content"></div>
                 </div>
             </div>`
 })


### PR DESCRIPTION
Ajuste en la comparación de horas en plex-datetime.  Había un error al comparar el valor actual con la fecha min y max. Se comparava la día y hora, en vez de la hora sola. 

Ver ejemplo en demo.