### PR TITLE
mejora plex-button validateForm

### DIFF
--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -33,17 +33,17 @@
         </fieldset>
         <fieldset>
             <legend>Validación de formularios</legend>
-            <form>
+            <form #formulario1="ngForm">
                 <plex-text label="Este es un campo de texto requerido" name="campo1" [(ngModel)]="modelo.campo1" [disabled]="false" [required]="true"></plex-text>
-                <plex-button type="success" label="Guardar formulario" icon="content-save" validateForm="true" (click)="guardar($event)"></plex-button>
+                <plex-button type="success" label="Guardar formulario" icon="content-save" [validateForm]="formulario1" (click)="guardar($event)"></plex-button>
             </form>
         </fieldset>
         <fieldset>
             <legend>Formulario inline</legend>
-            <form>
+            <form #formulario2="ngForm">
                 <div class="btn-group">
                     <plex-text name="campo1" [(ngModel)]="modelo.campo1" [disabled]="false" [required]="true"></plex-text>
-                    <plex-button type="success" icon="content-save" validateForm="true" (click)="guardar($event)"></plex-button>
+                    <plex-button type="success" icon="content-save" [validateForm]="formulario2" (click)="guardar($event)"></plex-button>
                 </div>
             </form>
         </fieldset>

--- a/src/lib/button/button.component.ts
+++ b/src/lib/button/button.component.ts
@@ -16,10 +16,10 @@ export class PlexButtonComponent {
     @Input() icon: string;
     @Input() type: string;
     @Input() size: 'lg' | 'sm' | 'block';
-    @Input() validateForm: boolean;
+    @Input() validateForm: boolean | NgForm;
     @Input() @HostBinding('attr.disabled') disabled: boolean;
 
-    constructor( @Optional() private form?: NgForm) {
+    constructor(@Optional() private parentForm?: NgForm) {
         this.type = 'default';
         this.disabled = false;
         this.size = null;
@@ -37,13 +37,18 @@ export class PlexButtonComponent {
             // return false;
         } else {
             // Si está asociado a un formulario, fuerza la validación de los controles
-            if (this.validateForm && this.form) {
-                for (let key in this.form.controls) {
-                    this.form.controls[key].markAsDirty();
+            if (this.validateForm) {
+                let form: NgForm = (this.validateForm instanceof NgForm) ? (this.validateForm as NgForm) : this.parentForm;
+                if (!form) {
+                    throw new Error('plex-button no pudo vincularse a ningún NgForm');
+                }
+
+                for (let key in form.controls) {
+                    form.controls[key].markAsDirty();
                 }
                 // Inyecta la propiedad para que sea fácilmente accesible desde los controladores
                 if (event) {
-                    (event as any).formValid = this.form.valid;
+                    (event as any).formValid = form.valid;
                 }
             }
         }


### PR DESCRIPTION
-  Implementa mejora para que plex-button tome como parámetro un NgForm en la propiedad validateForm

Esto permite que un botón fuera del form pueda acceder a la validación. Por ejemplo: el form puede estar dentro del main container y el botón en el footer 