### PR TITLE
plex select: preload elemento

### DIFF
--- a/src/demo/app/select/select.component.ts
+++ b/src/demo/app/select/select.component.ts
@@ -40,6 +40,15 @@ export class SelectDemoComponent implements OnInit {
 
         this.modelo1.select = this.modelo2.select = this.opciones[1];
         this.rModelo1.select = this.opciones[2];
+
+        setTimeout(() => {
+            this.modelo2.select = {
+                _id: '5821da5ab6f2bac35980c464',
+                nombre: 'Arabia Saudita',
+                id: '5821da5ab6f2bac35980c464'
+            };
+
+        }, 10000);
     }
 
     loadData(event: SelectEvent) {

--- a/src/lib/core/service.ts
+++ b/src/lib/core/service.ts
@@ -78,27 +78,6 @@ export class Plex {
     }
 
     /**
-     * Muestra un mensaje de alerta
-     *
-     * @param {string} content Texto
-     * @param {string} [title='Información'] Título
-     * @returns {Promise<any>} Devuelve una promise se que resuelve cuando la alerta se cierra
-     *
-     * @memberof Plex
-     * @deprecated Utilizar el método info()
-     */
-    alert(content: string, title = 'Información', confirmButtonText = 'ACEPTAR'): Promise<any> {
-        return swal({
-            title,
-            html: content,
-            type: 'warning',
-            confirmButtonText: confirmButtonText.toLocaleUpperCase(),
-            buttonsStyling: false,
-            confirmButtonClass: 'btn btn-warning',
-        });
-    }
-
-    /**
      * TODO: Migrar para usar 1 sólo objeto con su type como param
      * Muestra un diálogo de confirmación
      *

--- a/src/lib/select/select.component.ts
+++ b/src/lib/select/select.component.ts
@@ -339,7 +339,10 @@ export class PlexSelectComponent implements AfterViewInit, ControlValueAccessor 
             }
 
             // Setea el valor
-            this.selectize.setValue(val, true);
+            if (value) {
+                this.selectize.addOption(value);
+                this.selectize.setValue(val, true);
+            }
         }
     }
 


### PR DESCRIPTION
Cuando se combinaba el ngModel con el (getData) en el plex-select, no se visualizaba el elemento hasta que no se realizaba una primer busqueda. 

Agrega el método `addOption` de selectize antes de selecionar el elemento.

PD: RIP plex.alert.


