### PR TITLE
Selectize height

### DIFF
--- a/src/demo/app/datetime/datetime.component.ts
+++ b/src/demo/app/datetime/datetime.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { NgForm } from '@angular/forms';
 
 @Component({
     templateUrl: 'datetime.html',

--- a/src/demo/app/datetime/datetime.html
+++ b/src/demo/app/datetime/datetime.html
@@ -1,43 +1,45 @@
 <plex-layout>
-  <plex-layout-main>
-    <div class="row">
-      <div class="col-md-6">
-        <form #form="ngForm">
-          <plex-datetime label="Ingrese la fecha y la hora del evento" [(ngModel)]="tModel.fechaHora" name="fechaHora"
-                         required>
-          </plex-datetime>
-          <plex-datetime label="Ingrese la fecha del cumpleaños mayor a 1/1/1970" type="date" [(ngModel)]="tModel.fecha"
-                         name="fecha" [required]="true" [min]="tModel.min" [max]="tModel.max">
-          </plex-datetime>
+    <plex-layout-main>
+        <div class="row">
+            <div class="col-md-6">
+                <form #form="ngForm">
+                    <plex-datetime label="Ingrese la fecha y la hora del evento" [(ngModel)]="tModel.fechaHora"
+                                   name="fechaHora" required>
+                    </plex-datetime>
+                    <plex-datetime label="Ingrese la fecha del cumpleaños mayor a 1/1/1970" type="date"
+                                   [(ngModel)]="tModel.fecha" name="fecha" [required]="true" [min]="tModel.min"
+                                   [max]="tModel.max">
+                    </plex-datetime>
 
 
-          <plex-datetime label="Ingrese la hora de nacimiento" type="time" [(ngModel)]="tModel.hora" name="hora"
-                         (blur)="onBlur()" (focus)="onBlur()">
-          </plex-datetime>
+                    <plex-datetime label="Ingrese la hora de nacimiento" type="time" [(ngModel)]="tModel.hora"
+                                   name="hora" (blur)="onBlur()" (focus)="onBlur()">
+                    </plex-datetime>
 
-          <plex-datetime label="Ingrese la hora de nacimient2o" type="time" [(ngModel)]="tModel.horados"
-                         [min]="horaPlus()" name="hora2">
-          </plex-datetime>
+                    <plex-datetime label="Ingrese la hora de nacimient2o" type="time" [(ngModel)]="tModel.horados"
+                                   [min]="horaPlus()" name="hora2">
+                    </plex-datetime>
 
-          <plex-datetime label="Este campo es readonly" type="time" [(ngModel)]="tModel.hora2" name="hora2"
-                         [readonly]="model4.disabled">
-          </plex-datetime>
+                    <plex-datetime label="Este campo es readonly" type="time" [(ngModel)]="tModel.hora2" name="hora2"
+                                   [readonly]="model4.disabled">
+                    </plex-datetime>
 
 
-          <plex-button label="Actualizar maxHora" (click)="updateMaxHora()"></plex-button>
-          <plex-datetime label="Fecha con navegación inline (por dia)" [skipBy]="'day'" [(ngModel)]="tModel.fecha"
-                         [min]="tModel.min" [max]="tModel.max" name="fechaSkip" required>
-          </plex-datetime>
-          <plex-datetime label="Hora con navegación inline (por hora)" type="time" [skipBy]="'hour'"
-                         [(ngModel)]="tModel.fechaHora" [min]="tModel.minHora" [max]="tModel.maxHora" name="horaSkip"
-                         required>
-          </plex-datetime>
-        </form>
-      </div>
-      <div class="col-md-6">
-        <label>Modelo</label>
-        <pre>{{ tModel | json }}</pre>
-      </div>
-    </div>
-  </plex-layout-main>
+                    <plex-button label="Actualizar maxHora" (click)="updateMaxHora()"></plex-button>
+                    <plex-datetime label="Fecha con navegación inline (por dia)" [skipBy]="'day'"
+                                   [(ngModel)]="tModel.fecha" [min]="tModel.min" [max]="tModel.max" name="fechaSkip"
+                                   required>
+                    </plex-datetime>
+                    <plex-datetime label="Hora con navegación inline (por hora)" type="time" [skipBy]="'hour'"
+                                   [(ngModel)]="tModel.fechaHora" [min]="tModel.minHora" [max]="tModel.maxHora"
+                                   name="horaSkip" required>
+                    </plex-datetime>
+                </form>
+            </div>
+            <div class="col-md-6">
+                <label>Modelo</label>
+                <pre>{{ tModel | json }}</pre>
+            </div>
+        </div>
+    </plex-layout-main>
 </plex-layout>

--- a/src/lib/css/plex-box.scss
+++ b/src/lib/css/plex-box.scss
@@ -10,6 +10,7 @@ plex-box > DIV {
     & > header {
       margin-bottom: 15px;
       border-bottom: solid grey 1px;
+      border-bottom: solid #aaa 1px;
     }
 
     & > .plex-box-content {

--- a/src/lib/css/plex-select.scss
+++ b/src/lib/css/plex-select.scss
@@ -9,7 +9,7 @@ $selectize-font-size: 1em !default;
 $selectize-line-height: 18px !default;
 
 $selectize-color-text: #303030 !default;
-$selectize-color-border: #d0d0d0 !default;
+$selectize-color-border: rgba(0, 0, 0, 0.15) !default;
 $selectize-color-highlight: rgba(125,168,208,0.2) !default;
 $selectize-color-input: white !default;
 $selectize-color-input-full: $selectize-color-input !default;
@@ -117,7 +117,6 @@ $selectize-caret-margin-rtl: 0 4px 0 -2px !default;
   padding: $selectize-padding-y $selectize-padding-x;
   display: inline-block;
   width: 100%;
-  overflow: hidden;
   position: relative;
   z-index: 1;
   @include selectize-box-sizing (border-box);
@@ -518,6 +517,7 @@ $selectize-arrow-offset: $selectize-padding-x + 5px !default;
   height: auto;
   border: none;
   background: none;
+  line-height: 0;
   @include selectize-box-shadow (none);
   @include selectize-border-radius (0);
 }

--- a/src/lib/select/select.component.ts
+++ b/src/lib/select/select.component.ts
@@ -3,7 +3,7 @@ import { ControlValueAccessor, NgControl, NG_VALUE_ACCESSOR, Validators, Abstrac
 import { SelectEvent } from './select-event.interface';
 import { hasRequiredValidator } from '../core/validator.functions';
 
-// Importo las librería
+// Importo las librerías
 const Selectize = require('selectize/dist/js/standalone/selectize');
 
 @Component({
@@ -17,9 +17,9 @@ const Selectize = require('selectize/dist/js/standalone/selectize');
         }
     ],
     template: ` <div class="form-group" [ngClass]="{'has-danger': hasDanger() }">
-                    <label *ngIf="label" class="form-control-label">{{label}}<span *ngIf="control.name && esOpcional" class="opcional"></span></label>
-                    <select *ngIf="!multiple" id="{{uniqueId}}" (change)="onChange($event.target.value)"></select>
-                    <select *ngIf="multiple" id="{{uniqueId}}" multiple (change)="onChange($event.target.value)"></select>
+                    <label *ngIf="label" class="form-control-label">{{ label }}<span *ngIf="esOpcional" class="opcional"></span></label>
+                    <select *ngIf="!multiple" id="{{ uniqueId }}" (change)="onChange($event.target.value)"></select>
+                    <select *ngIf="multiple" id="{{ uniqueId }}" multiple (change)="onChange($event.target.value)"></select>
                     <plex-validation-messages *ngIf="hasDanger()" [control]="control"></plex-validation-messages>
                 </div>`,
 })
@@ -37,7 +37,7 @@ export class PlexSelectComponent implements AfterViewInit, ControlValueAccessor 
     }
 
     public hasDanger() {
-        return (this.control as any).name && (this.control.dirty || this.control.touched) && !this.control.valid;
+        return (this.control.dirty || this.control.touched) && !this.control.valid;
     }
 
     // Propiedades


### PR DESCRIPTION
Se corrigen inconsistencias de plex-select con respecto a otros elementos de formulario:

- La propiedad `border-color` del contenedor de datos era `#f0f0f0` cuando en los demás elementos era `rgba(0, 0, 0, 0.15)`
- La propiedad `line-height` era `1.5` (heredada de body) cuando debería ser `1.25` como los demás elementos (se resetea a `0` para que herede las mismas reglas)
- Se elimina dolor ojos 