### PR TITLE
PLEX - color de placeholders

### DIFF
--- a/src/lib/css/plex-text.scss
+++ b/src/lib/css/plex-text.scss
@@ -26,4 +26,12 @@ plex-text {
     resize: none;
     min-height: $input-height;
   }
+
+  input {
+    ::placeholder {
+      color: $input-color-placeholder !important;
+      font-style: italic !important;
+      opacity: 1;
+    }
+    
 }

--- a/src/lib/css/plex-text.scss
+++ b/src/lib/css/plex-text.scss
@@ -33,5 +33,7 @@ plex-text {
       font-style: italic !important;
       opacity: 1;
     }
-    
+  
+  }
+
 }

--- a/src/lib/css/variables.scss
+++ b/src/lib/css/variables.scss
@@ -59,7 +59,7 @@ $border-radius-sm: 0;
 $input-border-radius: 0;
 $input-border-radius-lg: 0;
 $input-border-radius-sm: 0;
-$input-color-placeholder: #e3e3e3;
+$input-color-placeholder: #696969;
 $form-group-margin-bottom: 0;
 
 // Validation states


### PR DESCRIPTION
En algunas pantallas los placeholders no se leen.
Se cambió el color de los mismos, dando más contraste y por tanto mejor legibilidad.