### PR TITLE
PLEX: Evitar perdida de formato en plex-text con html

### DIFF
--- a/src/lib/text/text.component.ts
+++ b/src/lib/text/text.component.ts
@@ -59,6 +59,8 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
     // Public
     public isEmpty = true;
     public quill = {
+        syntax: true,
+        strict: false,
         toolbar: [
             ['bold', 'italic', 'underline'],
             [{ list: 'ordered' }, { list: 'bullet' }],
@@ -149,11 +151,13 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
             this.adjustTextArea();
         } else {
             if (this.html) {
-                const component = (this.quillEditor as any);
-                // Por el dinamismo de RUP hay una primera instancia que quillEditor es undefined
-                if (component.quillEditor) {
-                    component.quillEditor.setContents(component.valueSetter(component.quillEditor, typeof value === 'undefined' ? '' : value));
-                }
+                setTimeout(() => {
+                    const component = (this.quillEditor as any);
+                    // Por el dinamismo de RUP hay una primera instancia que quillEditor es undefined
+                    if (component.quillEditor) {
+                        component.quillEditor.setContents(value);
+                    }
+                }, 1000);
             }
         }
         // Check empty


### PR DESCRIPTION
### ISSUE
* https://github.com/andes/app/issues/1435

### Funcionalidad desarrollada 
1. Cuando la opción de html del plex-text está activa, se agrega un tiempo de espera al definir el valor del contenido

### UserStory llegó a completarse
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No
