### PR TITLE
Nuevas funcionalidades de plex-datetime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     working_directory: ~/app
     docker:
       - image: circleci/node:10-browsers
+        environment:
+          TZ: "America/Argentina/Buenos_Aires"
     steps:
       - checkout
       - restore_cache:
@@ -27,8 +29,12 @@ jobs:
             - app
   build:
     working_directory: ~/app
+    environment:
+          TZ: "America/Argentina/Buenos_Aires"
     docker:
       - image: circleci/node:10-browsers
+        environment:
+          TZ: "America/Argentina/Buenos_Aires"
     steps:
       - attach_workspace:
           at: ~/
@@ -44,10 +50,13 @@ jobs:
 
   cypress:
     working_directory: ~/app
+    environment:
+      TZ: "America/Argentina/Buenos_Aires"
     docker:
       - image: cypress/base:10
         environment:
-          TERM: xterm
+          TERM: xterm 
+          TZ: "America/Argentina/Buenos_Aires"
     steps:
       - attach_workspace:
           at: ~/
@@ -61,6 +70,8 @@ jobs:
     working_directory: ~/app
     docker:
       - image: circleci/node:10-browsers
+        environment:
+          TZ: "America/Argentina/Buenos_Aires"
     steps:
       - attach_workspace:
           at: ~/

--- a/cypress/integration/datetime.js
+++ b/cypress/integration/datetime.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 
-context('bool', () => {
+context('datetime', () => {
     before(() => {
         cy.eyesOpen({ appName: 'PLEX', testName: 'datetime' });
 
@@ -46,6 +46,7 @@ context('bool', () => {
 
         cy.eyesCheckWindow('datetime - end');
 
+        cy.eyesClose();
 
 
 

--- a/cypress/integration/datetime.js
+++ b/cypress/integration/datetime.js
@@ -21,7 +21,6 @@ context('bool', () => {
 
         cy.get('.col-md-6').contains('1950-01-01T03:00:00.000Z');
 
-
         cy.plexDatetime('name="hora"', '13:00');
         cy.plexDatetime('name="horaconmin"', '10:00');
         cy.plexDatetime('name="horaconmin"').validationMessage('El valor debe ser mayor a');
@@ -44,6 +43,9 @@ context('bool', () => {
 
         cy.plexDatetime('name="fechaSkip"').find('input').should('have.value', '31/01/1970 00:00');
         cy.get('.col-md-6').contains('1970-01-31T03:00:00.000Z');
+
+        cy.eyesCheckWindow('datetime - end');
+
 
 
 

--- a/cypress/integration/datetime.js
+++ b/cypress/integration/datetime.js
@@ -1,0 +1,51 @@
+/// <reference types="Cypress" />
+
+context('bool', () => {
+    before(() => {
+        cy.eyesOpen({ appName: 'PLEX', testName: 'datetime' });
+
+        cy.visit('/datetime');
+    });
+
+    it('test datetime', () => {
+        cy.eyesCheckWindow('datetime - main');
+
+        cy.plexDatetime('label="Ingrese la fecha y la hora del evento"', '01/01/2019');
+        cy.plexDatetime('label="Fecha menor a"').click();
+        cy.plexDatetime('label="Ingrese la fecha y la hora del evento"').find('input').should('have.value', '01/01/2019 00:00');
+
+        cy.get('.col-md-6').contains('2019-01-01T03:00:00.000Z');
+
+        cy.plexDatetime('label="Fecha menor a"', '01/01/1950');
+        cy.plexDatetime('label="Fecha menor a"').validationMessage('El valor debe ser mayor a');
+
+        cy.get('.col-md-6').contains('1950-01-01T03:00:00.000Z');
+
+
+        cy.plexDatetime('name="hora"', '13:00');
+        cy.plexDatetime('name="horaconmin"', '10:00');
+        cy.plexDatetime('name="horaconmin"').validationMessage('El valor debe ser mayor a');
+        cy.plexDatetime('name="horaconmin"', { clear: true, text: '14:00' });
+
+        cy.plexDatetime('name="fechaSkip"').iconClick('menu-right');
+        cy.plexDatetime('name="fechaSkip"').find('input').should('have.value', '02/01/1950 00:00');
+        cy.plexDatetime('name="fechaSkip"').iconClick('menu-left');
+        cy.plexDatetime('name="fechaSkip"').find('input').should('have.value', '01/01/1950 00:00');
+
+        cy.plexDatetime('name="fechaSkip"').iconClick('calendar-clock');
+        cy.eyesCheckWindow('datetime - calendario');
+
+
+        cy.get('.table.dtp-picker-days').find('td[data-date="31"]').click({ multiple: true });
+
+        cy.eyesCheckWindow('datetime - hour pick');
+        cy.get('.dtp-picker-datetime').find('[id="h-0"]').click({ multiple: true, force: true });
+        cy.get('.dtp-picker-datetime').find('[id="m-0"]').click({ multiple: true, force: true });
+
+        cy.plexDatetime('name="fechaSkip"').find('input').should('have.value', '31/01/1970 00:00');
+        cy.get('.col-md-6').contains('1970-01-31T03:00:00.000Z');
+
+
+
+    });
+});

--- a/cypress/support/plex.js
+++ b/cypress/support/plex.js
@@ -187,8 +187,12 @@ Cypress.Commands.add('plexDatetime', { prevSubject: 'optional' }, (subject, labe
             element.type(`${data.text}{enter}`);
         }
     }
-    element = element.parent().parent().parent();
+    element = element.parent().parent();
     return element;
+});
+
+Cypress.Commands.add('iconClick', { prevSubject: 'element' }, (subject, icon) => {
+    return cy.wrap(subject).find(`i.mdi.mdi-${icon}`).click();
 });
 
 Cypress.Commands.add('plexBool', { prevSubject: 'optional' }, (subject, label, checked = false) => {

--- a/src/demo/app/datetime/datetime.component.ts
+++ b/src/demo/app/datetime/datetime.component.ts
@@ -40,4 +40,8 @@ export class DateTimeDemoComponent implements OnInit {
 
     onBlur() {
     }
+
+    onChange(date) {
+
+    }
 }

--- a/src/demo/app/datetime/datetime.html
+++ b/src/demo/app/datetime/datetime.html
@@ -34,6 +34,10 @@
                                    [(ngModel)]="tModel.fechaHora" [min]="tModel.minHora" [max]="tModel.maxHora"
                                    name="horaSkip" required>
                     </plex-datetime>
+
+                    <plex-datetime label="Datetime con debounce" name="debounce" type="date" [(ngModel)]="tModel.hora"
+                                   (change)="onChange($event)" [debounce]="1000">
+                    </plex-datetime>
                 </form>
             </div>
             <div class="col-md-6">

--- a/src/demo/app/datetime/datetime.html
+++ b/src/demo/app/datetime/datetime.html
@@ -6,18 +6,16 @@
                     <plex-datetime label="Ingrese la fecha y la hora del evento" [(ngModel)]="tModel.fechaHora"
                                    name="fechaHora" required>
                     </plex-datetime>
-                    <plex-datetime label="Ingrese la fecha del cumpleaños mayor a 1/1/1970" type="date"
-                                   [(ngModel)]="tModel.fecha" name="fecha" [required]="true" [min]="tModel.min"
-                                   [max]="tModel.max">
+                    <plex-datetime label="Fecha menor a" type="date" [(ngModel)]="tModel.fecha" name="fecha"
+                                   [required]="true" [min]="tModel.min" [max]="tModel.max">
                     </plex-datetime>
-
 
                     <plex-datetime label="Ingrese la hora de nacimiento" type="time" [(ngModel)]="tModel.hora"
                                    name="hora" (blur)="onBlur()" (focus)="onBlur()">
                     </plex-datetime>
 
                     <plex-datetime label="Ingrese la hora de nacimient2o" type="time" [(ngModel)]="tModel.horados"
-                                   [min]="horaPlus()" name="hora2">
+                                   [min]="horaPlus()" name="horaconmin">
                     </plex-datetime>
 
                     <plex-datetime label="Este campo es readonly" type="time" [(ngModel)]="tModel.hora2" name="hora2"

--- a/src/demo/app/datetime/datetime.html
+++ b/src/demo/app/datetime/datetime.html
@@ -7,11 +7,11 @@
                                    name="fechaHora" required>
                     </plex-datetime>
                     <plex-datetime label="Fecha menor a" type="date" [(ngModel)]="tModel.fecha" name="fecha"
-                                   [required]="true" [min]="tModel.min" [max]="tModel.max">
+                                   [required]="true" [min]="tModel.min" [max]="tModel.max" size="lg">
                     </plex-datetime>
 
                     <plex-datetime label="Ingrese la hora de nacimiento" type="time" [(ngModel)]="tModel.hora"
-                                   name="hora" (blur)="onBlur()" (focus)="onBlur()">
+                                   name="hora" (blur)="onBlur()" (focus)="onBlur()" size="sm">
                     </plex-datetime>
 
                     <plex-datetime label="Ingrese la hora de nacimient2o" type="time" [(ngModel)]="tModel.horados"
@@ -28,7 +28,7 @@
                                    [(ngModel)]="tModel.fecha" [min]="tModel.min" [max]="tModel.max" name="fechaSkip"
                                    required>
                     </plex-datetime>
-                    <plex-datetime label="Hora con navegación inline (por hora)" type="time" [skipBy]="'hour'"
+                    <plex-datetime label="Hora con navegación inline (por hora)" type="time" [skipBy]="'hour'" size="sm"
                                    [(ngModel)]="tModel.fechaHora" [min]="tModel.minHora" [max]="tModel.maxHora"
                                    name="horaSkip" required>
                     </plex-datetime>

--- a/src/demo/app/datetime/datetime.html
+++ b/src/demo/app/datetime/datetime.html
@@ -1,8 +1,8 @@
 <plex-layout>
     <plex-layout-main>
-        <div class="row">
-            <div class="col-md-6">
-                <form #form="ngForm">
+        <form #form="ngForm">
+            <div class="row">
+                <div class="col-md-6">
                     <plex-datetime label="Ingrese la fecha y la hora del evento" [(ngModel)]="tModel.fechaHora"
                                    name="fechaHora" required>
                     </plex-datetime>
@@ -28,6 +28,10 @@
                                    [(ngModel)]="tModel.fecha" [min]="tModel.min" [max]="tModel.max" name="fechaSkip"
                                    required>
                     </plex-datetime>
+                </div>
+                <div class="col-md-6">
+                    <label>Modelo</label>
+                    <pre>{{ tModel | json }}</pre>
                     <plex-datetime label="Hora con navegación inline (por hora)" type="time" [skipBy]="'hour'" size="sm"
                                    [(ngModel)]="tModel.fechaHora" [min]="tModel.minHora" [max]="tModel.maxHora"
                                    name="horaSkip" required>
@@ -36,12 +40,11 @@
                     <plex-datetime label="Datetime con debounce" name="debounce" type="date" [(ngModel)]="tModel.hora"
                                    (change)="onChange($event)" [debounce]="1000">
                     </plex-datetime>
-                </form>
+
+                    <plex-datetime [(ngModel)]="tModel.fechaHora" name="onlybtn" required [btnOnly]="true" size="sm">
+                    </plex-datetime>
+                </div>
             </div>
-            <div class="col-md-6">
-                <label>Modelo</label>
-                <pre>{{ tModel | json }}</pre>
-            </div>
-        </div>
+        </form>
     </plex-layout-main>
 </plex-layout>

--- a/src/lib/datetime/datetime.component.spec.ts
+++ b/src/lib/datetime/datetime.component.spec.ts
@@ -1,0 +1,179 @@
+
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By, BrowserModule } from '@angular/platform-browser';
+import { Component, DebugElement, Type, ViewChild } from '@angular/core';
+
+import { PlexDateTimeComponent } from './datetime.component';
+import { PlexModule } from '../module';
+import { FormsModule } from '@angular/forms';
+
+describe('PlexDateTimeComponent', () => {
+    describe('input simple text', () => {
+        let fixture: ComponentFixture<PlexDateTimeTestComponent>;
+        let datetime: PlexDateTimeComponent;
+        let input: HTMLInputElement;
+        let nativeText: HTMLInputElement;
+
+        beforeEach(fakeAsync(() => {
+            fixture = createTestingModule(
+                PlexDateTimeTestComponent,
+                `<plex-datetime [(ngModel)]="text" type="date" (change)="onChange($event)" (focus)="onFocus()">
+                </plex-datetime>`);
+            datetime = fixture.componentInstance.plexDateTime;
+            input = getElement(fixture, 'plex-datetime input').nativeElement;
+            nativeText = getElement(fixture, 'plex-datetime').nativeElement;
+        }));
+
+        it('writing must update Input variable', fakeAsync(() => {
+            tickAndDetectChanges(fixture);
+            writeText(input, '01/01/2019');
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.text.toJSON().substr(0, 10)).toBe('2019-01-01');
+        }));
+
+        it('changing input var must update html DOM', fakeAsync(() => {
+            tickAndDetectChanges(fixture);
+            fixture.componentInstance.text = new Date(2019, 0, 1);
+            tickAndDetectChanges(fixture);
+            expect(input.value).toBe('01/01/2019');
+        }));
+
+        it('after write change must be called', fakeAsync(() => {
+            spyOn(fixture.componentInstance, 'onChange');
+            writeText(input, '01/01/2019');
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.onChange).toHaveBeenCalled();
+        }));
+
+        it('focus on click', fakeAsync(() => {
+            spyOn(fixture.componentInstance, 'onFocus');
+            nativeText.dispatchEvent(new Event('focus'));
+
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.onFocus).toHaveBeenCalled();
+        }));
+    });
+
+    describe('readonly check', () => {
+        let fixture: ComponentFixture<PlexDateTimeTestComponent>;
+        let input: HTMLInputElement;
+
+        beforeEach(fakeAsync(() => {
+            fixture = createTestingModule(
+                PlexDateTimeTestComponent,
+                `<plex-datetime [(ngModel)]="text" (change)="onChange($event)" [readonly]="true">
+                </plex-datetime>`);
+            input = getElement(fixture, 'plex-datetime input').nativeElement;
+        }));
+
+        it('readonly properties', fakeAsync(() => {
+            const readonly = getElement(fixture, 'plex-datetime input').nativeElement.getAttribute('readonly');
+            expect(readonly).toBeDefined();
+        }));
+
+    });
+
+    describe('input debounce text', () => {
+        let fixture: ComponentFixture<PlexDateTimeTestComponent>;
+        let text: PlexDateTimeComponent;
+        let input: HTMLInputElement;
+        let nativeText: HTMLInputElement;
+
+        beforeEach(fakeAsync(() => {
+            fixture = createTestingModule(
+                PlexDateTimeTestComponent,
+                `<plex-datetime [(ngModel)]="text" (change)="onChange($event)" [debounce]="1000">
+                </plex-datetime>`);
+            text = fixture.componentInstance.plexDateTime;
+            input = getElement(fixture, 'plex-datetime input').nativeElement;
+            nativeText = getElement(fixture, 'plex-datetime').nativeElement;
+        }));
+
+        it('after write change must be called', fakeAsync(() => {
+            spyOn(fixture.componentInstance, 'onChange');
+            writeText(input, '01/01/2019');
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.onChange).toHaveBeenCalledTimes(0);
+            tick(1100);
+            expect(fixture.componentInstance.onChange).toHaveBeenCalled();
+        }));
+
+    });
+});
+
+function writeText(element, text) {
+    element.value = text;
+    element.dispatchEvent(new Event('input'));
+}
+
+function tickAndDetectChanges(fixture: ComponentFixture<any>) {
+    fixture.detectChanges();
+    tick();
+}
+
+function getElement(fixture: ComponentFixture<any>, selector: string): DebugElement {
+    return fixture.debugElement.query(By.css(selector));
+}
+
+
+@Component({
+    template: ``
+})
+class PlexDateTimeTestComponent {
+    @ViewChild(PlexDateTimeComponent, { static: false }) plexDateTime: PlexDateTimeComponent;
+    text;
+
+    onChange(_: Event) {
+    }
+
+    onFocus(_: Event) {
+    }
+
+    onBlur(_: Event) {
+    }
+
+    onOpen() {
+    }
+
+    onClose() {
+    }
+
+    onAdd() {
+    }
+
+    onRemove() {
+    }
+
+    onClear() {
+    }
+
+    onSearch() {
+    }
+
+    onScroll() {
+    }
+
+    onScrollToEnd() {
+    }
+}
+
+function createTestingModule<T>(cmp: Type<T>, template: string): ComponentFixture<T> {
+
+    TestBed.configureTestingModule({
+        imports: [BrowserModule, PlexModule, FormsModule],
+        declarations: [cmp]
+    })
+        .overrideComponent(cmp, {
+            set: {
+                template
+            }
+        });
+
+
+    TestBed.compileComponents();
+
+    const fixture = TestBed.createComponent(cmp);
+    fixture.detectChanges();
+    return fixture;
+}
+

--- a/src/lib/datetime/datetime.component.ts
+++ b/src/lib/datetime/datetime.component.ts
@@ -27,12 +27,12 @@ require('./bootstrap-material-datetimepicker/bootstrap-material-datetimepicker')
     template: ` <div class="form-group" [ngClass]="{'has-danger': (control.dirty || control.touched) && !control.valid }">
                     <label *ngIf="label" class="form-control-label">{{ label }}</label>
                     <div class="input-group d-flex align-items-center">
-                        <a *ngIf="showNav" (click)="prev()" class="btn btn-info text-white pl-1 pr-1 hover" [title]="makeTooltip('anterior')"><i class="mdi mdi-menu-left"></i></a>
-                        <input type="text" class="form-control" [placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly" (input)="onChange($event.target.value)" (blur)="onBlur()" (focus)="onFocus()" (change)="disabledEvent($event)"/>
+                        <a *ngIf="showNav" (click)="prev()" class="btn btn-info btn-{{size}} text-white pl-1 pr-1 hover" [title]="makeTooltip('anterior')"><i class="mdi mdi-menu-left"></i></a>
+                        <input type="text" class="form-control form-control-{{size}}" [placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly" (input)="onChange($event.target.value)" (blur)="onBlur()" (focus)="onFocus()" (change)="disabledEvent($event)"/>
                         <span class="input-group-btn">
-                        <button class="btn btn-primary" tabindex="-1" [disabled]="disabled || readonly"><i class="mdi" [ngClass]="{'mdi-calendar': type == 'date','mdi-clock': type == 'time', 'mdi-calendar-clock': type == 'datetime'}"></i></button>
+                        <button class="btn btn-primary btn-{{size}}" tabindex="-1" [disabled]="disabled || readonly"><i class="mdi" [ngClass]="{'mdi-calendar': type == 'date','mdi-clock': type == 'time', 'mdi-calendar-clock': type == 'datetime'}"></i></button>
                         </span>
-                        <a *ngIf="showNav" (click)="next()" class="btn btn-info text-white pl-1 pr-1 hover" [title]="makeTooltip('siguiente')"><i class="mdi mdi-menu-right"></i></a>
+                        <a *ngIf="showNav" (click)="next()" class="btn btn-info btn-{{size}} text-white pl-1 pr-1 hover" [title]="makeTooltip('siguiente')"><i class="mdi mdi-menu-right"></i></a>
                     </div>
                     <plex-validation-messages *ngIf="hasDanger()" [control]="control"></plex-validation-messages>
                 </div>`,
@@ -61,6 +61,7 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges {
     @Input() skipBy: 'hour' | 'day' | 'month' | 'year' = null;
     @Input() title: string;
     @Input() debounce = 0;
+    @Input() size: 'sm' | 'md' | 'lg' = 'md';
 
     @Input()
     get min(): Date | moment.Moment {

--- a/src/lib/datetime/datetime.component.ts
+++ b/src/lib/datetime/datetime.component.ts
@@ -28,7 +28,7 @@ require('./bootstrap-material-datetimepicker/bootstrap-material-datetimepicker')
                     <label *ngIf="label" class="form-control-label">{{ label }}</label>
                     <div class="input-group d-flex align-items-center">
                         <a *ngIf="showNav" (click)="prev()" class="btn btn-info text-white pl-1 pr-1 hover" [title]="makeTooltip('anterior')"><i class="mdi mdi-menu-left"></i></a>
-                        <input type="text" class="form-control" [placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly" (input)="onChange($event.target.value)" (blur)="onBlur()" (focus)="onFocus()"/>
+                        <input type="text" class="form-control" [placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly" (input)="onChange($event.target.value)" (blur)="onBlur()" (focus)="onFocus()" (change)="disabledEvent($event)"/>
                         <span class="input-group-btn">
                         <button class="btn btn-primary" tabindex="-1" [disabled]="disabled || readonly"><i class="mdi" [ngClass]="{'mdi-calendar': type == 'date','mdi-clock': type == 'time', 'mdi-calendar-clock': type == 'datetime'}"></i></button>
                         </span>
@@ -115,6 +115,10 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges {
         this.type = 'datetime';
     }
 
+    public disabledEvent(event: Event) {
+        event.stopImmediatePropagation();
+        return false;
+    }
     // Inicialización
     ngOnInit() { }
     ngAfterViewInit() {

--- a/src/lib/datetime/datetime.component.ts
+++ b/src/lib/datetime/datetime.component.ts
@@ -24,15 +24,24 @@ require('./bootstrap-material-datetimepicker/bootstrap-material-datetimepicker')
             multi: true
         },
     ],
-    template: ` <div class="form-group" [ngClass]="{'has-danger': (control.dirty || control.touched) && !control.valid }">
+    template: `<div class="form-group" [ngClass]="{'has-danger': (control.dirty || control.touched) && !control.valid }">
                     <label *ngIf="label" class="form-control-label">{{ label }}</label>
                     <div class="input-group d-flex align-items-center">
-                        <a *ngIf="showNav" (click)="prev()" class="btn btn-info btn-{{size}} text-white pl-1 pr-1 hover" [title]="makeTooltip('anterior')"><i class="mdi mdi-menu-left"></i></a>
-                        <input type="text" class="form-control form-control-{{size}}" [placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly" (input)="onChange($event.target.value)" (blur)="onBlur()" (focus)="onFocus()" (change)="disabledEvent($event)"/>
+                        <a *ngIf="showNav" (click)="prev()" class="btn btn-info btn-{{size}} text-white pl-1 pr-1 hover"
+                           [title]="makeTooltip('anterior')">
+                           <i class="mdi mdi-menu-left"></i>
+                        </a>
+                        <input type="text" class="form-control form-control-{{size}}" [placeholder]="placeholder" [disabled]="disabled"
+                               [readonly]="readonly" (input)="onChange($event.target.value)" (blur)="onBlur()" (focus)="onFocus()"
+                               (change)="disabledEvent($event)" *ngIf="showInput"/>
                         <span class="input-group-btn">
-                        <button class="btn btn-primary btn-{{size}}" tabindex="-1" [disabled]="disabled || readonly"><i class="mdi" [ngClass]="{'mdi-calendar': type == 'date','mdi-clock': type == 'time', 'mdi-calendar-clock': type == 'datetime'}"></i></button>
+                            <button class="btn btn-primary btn-{{size}}" tabindex="-1" [disabled]="disabled || readonly">
+                                <i class="mdi" [ngClass]="{'mdi-calendar': type == 'date','mdi-clock': type == 'time', 'mdi-calendar-clock': type == 'datetime'}"></i>
+                            </button>
                         </span>
-                        <a *ngIf="showNav" (click)="next()" class="btn btn-info btn-{{size}} text-white pl-1 pr-1 hover" [title]="makeTooltip('siguiente')"><i class="mdi mdi-menu-right"></i></a>
+                        <a *ngIf="showNav" (click)="next()" class="btn btn-info btn-{{size}} text-white pl-1 pr-1 hover" [title]="makeTooltip('siguiente')">
+                            <i class="mdi mdi-menu-right"></i>
+                        </a>
                     </div>
                     <plex-validation-messages *ngIf="hasDanger()" [control]="control"></plex-validation-messages>
                 </div>`,
@@ -62,6 +71,11 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges {
     @Input() title: string;
     @Input() debounce = 0;
     @Input() size: 'sm' | 'md' | 'lg' = 'md';
+    @Input() btnOnly = false;
+
+    public get showInput() {
+        return !this.btnOnly;
+    }
 
     @Input()
     get min(): Date | moment.Moment {

--- a/src/lib/datetime/datetime.component.ts
+++ b/src/lib/datetime/datetime.component.ts
@@ -44,6 +44,7 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges {
     private value: any;
     private $button: any;
     private $input: any;
+    private changeTimeout = null;
 
     @ContentChild(NgControl, { static: true }) control: AbstractControl;
     public get esOpcional(): boolean {
@@ -59,6 +60,8 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges {
     @Input() readonly = false;
     @Input() skipBy: 'hour' | 'day' | 'month' | 'year' = null;
     @Input() title: string;
+    @Input() debounce = 0;
+
     @Input()
     get min(): Date | moment.Moment {
         return this._min;
@@ -119,6 +122,7 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges {
         event.stopImmediatePropagation();
         return false;
     }
+
     // Inicialización
     ngOnInit() { }
     ngAfterViewInit() {
@@ -177,9 +181,14 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges {
 
             this.value = value;
             fn(value);
-            this.change.emit({
-                value
-            });
+            if (this.changeTimeout) {
+                clearTimeout(this.changeTimeout);
+            }
+            this.changeTimeout = setTimeout(() => {
+                this.change.emit({
+                    value
+                });
+            }, this.debounce);
         };
     }
 

--- a/src/lib/text/text.component.spec.ts
+++ b/src/lib/text/text.component.spec.ts
@@ -59,7 +59,7 @@ describe('PlexTextComponent', () => {
         }));
     });
 
-    describe('input debounce text', () => {
+    describe('readonly check', () => {
         let fixture: ComponentFixture<PlexTextTestComponent>;
         let input: HTMLInputElement;
 


### PR DESCRIPTION
- Parámetro de tamaño
- Propiedad debounce para evitar request masivos. Espera un tiempo antes de ejecutar el método `change`.
- Propiedad para ocultar el `input`, usar solo el botón para mostrar el calendario. 