### PR TITLE
Plex-badge con icon y button

### DIFF
--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -17,7 +17,7 @@ export class AppComponent implements OnInit {
             { label: 'Accordion', icon: 'view-day', route: '/accordion' },
             { label: 'Bool', icon: 'checkbox-marked-outline', route: '/bool' },
             { label: 'Box', icon: 'selection', route: '/box' },
-            { label: 'Button', icon: 'solid', route: '/button' },
+            { label: 'Button & Badge', icon: 'solid', route: '/button-badge' },
             { label: 'DateTime', icon: 'calendar', route: '/datetime' },
             { label: 'Detail', icon: 'account', route: '/detail' },
             { label: 'Dropdown', icon: 'menu-right', route: '/dropdown' },

--- a/src/demo/app/app.routes.ts
+++ b/src/demo/app/app.routes.ts
@@ -38,7 +38,7 @@ const appRoutes: Routes = [
     { path: 'radio', component: RadioDemoComponent },
     { path: 'int', component: IntDemoComponent },
     { path: 'float', component: FloatDemoComponent },
-    { path: 'button', component: ButtonDemoComponent },
+    { path: 'button-badge', component: ButtonDemoComponent },
     { path: 'tabs', component: TabsDemoComponent },
     { path: 'accordion', component: AccordionDemoComponent },
     { path: 'modal', component: ModalDemoComponent },

--- a/src/demo/app/button/button.component.ts
+++ b/src/demo/app/button/button.component.ts
@@ -8,6 +8,9 @@ export class ButtonDemoComponent implements OnInit {
     public modelo = {
         campo1: null
     };
+
+    color = 'red';
+
     constructor(private plex: Plex) { }
 
     ngOnInit(): void {

--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -1,51 +1,84 @@
-<plex-layout>
+<plex-layout main="6">
     <plex-layout-main>
-        <fieldset>
-            <legend>Tipos</legend>
-            <plex-button label="Default" icon="account" (click)="onClick()"></plex-button>
-            <plex-button label="Primary" type="primary" icon="account"></plex-button>
-            <plex-button label="Danger" type="danger" icon="account"></plex-button>
-            <plex-button label="Success" type="success" icon="account"></plex-button>
-            <plex-button label="Link" type="link" icon="account"></plex-button>
-        </fieldset>
-        <fieldset>
-            <legend>Estados</legend>
-            <plex-button label="Deshabilitado" icon="account" [disabled]="true" (click)="onDisabledClick()"></plex-button>
-        </fieldset>
-        <fieldset>
-            <legend>Tamaños</legend>
-            <plex-button type="danger" label="Large" size="lg"></plex-button>
-            <plex-button type="success" label="Small" size="md"></plex-button>
-            <div class="row">
-                <div class="col">
-                    <plex-button type="warning" label="Toda la columna (block)" size="block"></plex-button>
-                </div>
-                <div class="col">
-                </div>
+        <plex-title titulo="PLEX-BUTTON"></plex-title>
+        <plex-title size="sm" titulo="Tipos"></plex-title>
+        <plex-button label="Default" icon="account" (click)="onClick()"></plex-button>
+        <plex-button label="Primary" type="primary" icon="account"></plex-button>
+        <plex-button label="Danger" type="danger" icon="account"></plex-button>
+        <plex-button label="Success" type="success" icon="account"></plex-button>
+        <plex-button label="Link" type="link" icon="account"></plex-button>
+        <hr>
+        <plex-title size="sm" titulo="Estados"></plex-title>
+        <plex-button label="Deshabilitado" icon="account" [disabled]="true" (click)="onDisabledClick()"></plex-button>
+        <hr>
+        <plex-title size="sm" titulo="Tamaños"></plex-title>
+        <plex-button type="danger" label="Large" size="lg"></plex-button>
+        <plex-button type="success" label="Small" size="md"></plex-button>
+        <div class="row">
+            <div class="col">
+                <plex-button type="warning" label="Toda la columna (block)" size="block"></plex-button>
             </div>
-        </fieldset>
-        <fieldset>
-            <legend>Grupos</legend>
+            <div class="col">
+            </div>
+        </div>
+        <plex-title size="sm" titulo="Grupos"></plex-title>
+        <div class="btn-group">
+            <plex-button type="success" icon="account"></plex-button>
+            <plex-button type="danger" icon="clock"></plex-button>
+        </div>
+        <hr>
+        <plex-title size="sm" titulo="Validación de formularios"></plex-title>
+        <form #formulario1="ngForm">
+            <plex-text label="Este es un campo de texto requerido" name="campo1" [(ngModel)]="modelo.campo1"
+                       [disabled]="false" [required]="true"></plex-text>
+            <plex-button type="success" label="Guardar formulario" icon="content-save" [validateForm]="formulario1"
+                         (click)="guardar($event)"></plex-button>
+        </form>
+        <hr>
+        <plex-title size="sm" titulo="Formulario inline"></plex-title>
+        <form #formulario2="ngForm">
             <div class="btn-group">
-                <plex-button type="success" icon="account"></plex-button>
-                <plex-button type="danger" icon="clock"></plex-button>
+                <plex-text name="campo1" [(ngModel)]="modelo.campo1" [disabled]="false" [required]="true"></plex-text>
+                <plex-button type="success" icon="content-save" [validateForm]="formulario2" (click)="guardar($event)">
+                </plex-button>
             </div>
-        </fieldset>
-        <fieldset>
-            <legend>Validación de formularios</legend>
-            <form #formulario1="ngForm">
-                <plex-text label="Este es un campo de texto requerido" name="campo1" [(ngModel)]="modelo.campo1" [disabled]="false" [required]="true"></plex-text>
-                <plex-button type="success" label="Guardar formulario" icon="content-save" [validateForm]="formulario1" (click)="guardar($event)"></plex-button>
-            </form>
-        </fieldset>
-        <fieldset>
-            <legend>Formulario inline</legend>
-            <form #formulario2="ngForm">
-                <div class="btn-group">
-                    <plex-text name="campo1" [(ngModel)]="modelo.campo1" [disabled]="false" [required]="true"></plex-text>
-                    <plex-button type="success" icon="content-save" [validateForm]="formulario2" (click)="guardar($event)"></plex-button>
-                </div>
-            </form>
-        </fieldset>
+        </form>
     </plex-layout-main>
+    <plex-layout-sidebar>
+        <plex-title titulo="PLEX-BADGE"></plex-title>
+        <hr>
+
+        <plex-title size="sm" titulo="badge normal"></plex-title>
+        <plex-badge size="sm" type="success" class="mr-1">VALIDADO</plex-badge>
+        <plex-badge size="sm" type="warning" class="mr-1">TEMPORAL</plex-badge>
+        <plex-badge size="sm" type="danger" class="mr-1">RESTRINGIDO</plex-badge>
+        <plex-badge size="sm" type="info" class="mr-1">14/02/2020</plex-badge>
+
+        <hr>
+        <plex-title size="sm" titulo="button y badge"></plex-title>
+        <plex-badge size="sm" type="warning" class="mr-1">TEMPORAL
+            <plex-button icon="clock"></plex-button>
+        </plex-badge>
+        <plex-badge size="sm" type="danger" class="mr-1">RESTRINGIDO
+            <plex-button icon="clock"></plex-button>
+        </plex-badge>
+        <plex-badge size="sm" type="info" class="mr-1">14/02/2020
+            <plex-button icon="clock"></plex-button>
+        </plex-badge>
+
+        <hr>
+        <plex-title size="sm" titulo="icon y badge"></plex-title>
+        <plex-badge size="sm" type="success" class="mr-1">VALIDADO
+            <plex-icon name="clock"></plex-icon>
+        </plex-badge>
+
+        <hr>
+        <plex-title size="sm" titulo="icon + button"></plex-title>
+        <!-- <plex-badge size="sm" type="primary" class="mr-1">14/02/2020</plex-badge> -->
+        <plex-badge size="sm" type="success" class="mr-1">VALIDADO
+            <plex-icon name="clock"></plex-icon>
+            <plex-button icon="clock"></plex-button>
+        </plex-badge>
+
+    </plex-layout-sidebar>
 </plex-layout>

--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -66,6 +66,11 @@
             <plex-button icon="clock"></plex-button>
         </plex-badge>
 
+        <plex-badge size="sm" [color]="color" class="mr-1">
+            CUSTOM COLOR
+            <plex-button icon="clock" (click)="color = 'blue'"></plex-button>
+        </plex-badge>
+
         <hr>
         <plex-title size="sm" titulo="icon y badge"></plex-title>
         <plex-badge size="sm" type="success" class="mr-1">VALIDADO
@@ -75,10 +80,19 @@
         <hr>
         <plex-title size="sm" titulo="icon + button"></plex-title>
         <!-- <plex-badge size="sm" type="primary" class="mr-1">14/02/2020</plex-badge> -->
-        <plex-badge size="sm" type="success" class="mr-1">VALIDADO
+        <plex-badge size="sm" type="success" class="mr-1">
+            VALIDADO
             <plex-icon name="clock"></plex-icon>
             <plex-button icon="clock"></plex-button>
         </plex-badge>
+
+        <plex-badge size="sm" [color]="color" class="mr-1">
+            TEMPORAL
+            <plex-icon name="clock"></plex-icon>
+            <plex-button icon="clock"></plex-button>
+        </plex-badge>
+
+
 
     </plex-layout-sidebar>
 </plex-layout>

--- a/src/lib/badge/badge.component.ts
+++ b/src/lib/badge/badge.component.ts
@@ -7,7 +7,7 @@ import { Component, Input, ElementRef, ViewChild, OnChanges } from '@angular/cor
             <ng-content select="plex-icon"></ng-content>
             <ng-content></ng-content>
         </span>
-        <span class="btn-badge-{{ type }}">
+        <span #badgeBtn class="btn-badge btn-badge-{{ type }}">
             <ng-content select="plex-button"></ng-content>
         </span>
         `,
@@ -19,6 +19,8 @@ export class PlexBadgeComponent implements OnChanges {
 
     @ViewChild('badge', { static: true }) el: ElementRef;
 
+    @ViewChild('badgeBtn', { static: true }) badgeBtn: ElementRef;
+
     constructor() {
         this.type = 'success';
     }
@@ -26,6 +28,7 @@ export class PlexBadgeComponent implements OnChanges {
     ngOnChanges() {
         if (this.color && this.color.length > 0) {
             this.el.nativeElement.style.setProperty('--badge-color', this.color);
+            this.badgeBtn.nativeElement.style.setProperty('--badge-color', this.color);
         }
 
     }

--- a/src/lib/badge/badge.component.ts
+++ b/src/lib/badge/badge.component.ts
@@ -3,13 +3,17 @@ import { Component, Input, ElementRef, ViewChild, OnChanges } from '@angular/cor
 @Component({
     selector: 'plex-badge',
     template: `
-        <span #badge class="badge badge-{{type}} badge-{{size}}">
+        <span #badge class="badge badge-{{ type }} badge-{{ size }}">
+            <ng-content select="plex-icon"></ng-content>
             <ng-content></ng-content>
         </span>
-                `,
+        <span class="btn-badge-{{ type }}">
+            <ng-content select="plex-button"></ng-content>
+        </span>
+        `,
 })
 export class PlexBadgeComponent implements OnChanges {
-    @Input() type: string;
+    @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'primary';
     @Input() size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'md';
     @Input() color: string;
 

--- a/src/lib/css/plex-badge.scss
+++ b/src/lib/css/plex-badge.scss
@@ -5,13 +5,20 @@
     font-weight: normal;
     padding: 6px;
     text-transform: uppercase;
-    
-    >i {
-        margin-right: 5px;
-    }
-    
     border-color: var(--badge-color);
     color: var(--badge-color);
+    
+    i {
+        margin-right: 5px;
+        font-size: 20px;
+        overflow: hidden;
+        line-height: 0;
+        height: 0;
+        position: relative;
+        top: 3px;
+        right: 3px;
+        border-color: var(--badge-color);
+    }
 
 }
 
@@ -20,32 +27,17 @@
 }
 
 
-.badge-default {
-    --badge-color: #{$dark-grey}; 
-    @extend %baseBadge;
+.btn-badge {
+    button.btn {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        border-radius: 0;
+        color: #fff;
+        background-color: var(--badge-color);
+        border-color: var(--badge-color);
+    }
+
 }
-
-.badge-danger {
-    --badge-color: #{$red};
-    @extend %baseBadge;
-}
-
-.badge-success {
-    --badge-color: #{$green};
-    @extend %baseBadge;
-}
-
-.badge-warning {
-    --badge-color: #{$orange};
-    @extend %baseBadge;
-}
-
-.badge-info {
-    --badge-color: #{$blue};
-    @extend %baseBadge;
-}
-
-
 
 // Espaciado del ícono
 [class^="badge-"]>i,
@@ -53,11 +45,32 @@
     margin-right: 5px;
 }
 
+$colors: (
+    warning: $orange,
+    danger: $red,
+    success: $green,
+    info: $blue
+);
+
+@each $name, $color in $colors {
+    
+    .badge-#{$name} {
+        --badge-color: #{$color};
+        // Compatibilidad con andes hasta que se haga el refactor a plex-badge
+        @extend %baseBadge;
+    }
+
+    .btn-badge-#{$name} {
+        --badge-color: #{$color};
+    }
+    
+}
+
+
 /** BADGE EXTENSIBLE DESDE AFUERA DE PLEX */
 $badge-extend: () !default;
 
-@each $name,
-$color in $badge-extend {
+@each $name, $color in $badge-extend {
     .badge-#{$name} {
          --badge-color: #{$color};
     }
@@ -72,41 +85,3 @@ $color in $badge-extend {
         }
     }
 }
-
-$colors: (
-    warning: $orange,
-    danger: $red,
-    success: $green,
-    info: $blue
-);
-
-@each $name,
-$color in $colors {
-    .badge-#{$name} {
-         --badge-color: #{$color};
-    }
-    .btn-badge-#{$name} {
-        button.btn {
-            padding: 0.25rem 0.5rem;
-            font-size: 0.875rem;
-            border-radius: 0;
-            color: #fff;
-            background-color: #{$color};
-            border-color: #{$color};
-        }
-
-    }
-    .badge-#{$name} {
-        i {
-            font-size: 20px;
-            overflow: hidden;
-            line-height: 0;
-            height: 0;
-            position: relative;
-            top: 3px;
-            right: 3px;
-            border-color: #{$color};
-        }
-    }
-}
-

--- a/src/lib/css/plex-badge.scss
+++ b/src/lib/css/plex-badge.scss
@@ -12,12 +12,13 @@
     
     border-color: var(--badge-color);
     color: var(--badge-color);
+
 }
 
 .badge {
     @extend %baseBadge;
 }
- 
+
 
 .badge-default {
     --badge-color: #{$dark-grey}; 
@@ -44,6 +45,8 @@
     @extend %baseBadge;
 }
 
+
+
 // Espaciado del ícono
 [class^="badge-"]>i,
 [class^="label-"]>i {
@@ -56,6 +59,54 @@ $badge-extend: () !default;
 @each $name,
 $color in $badge-extend {
     .badge-#{$name} {
-         --badge-color: $color;
+         --badge-color: #{$color};
+    }
+    .btn-badge-#{$name} {
+        .btn {
+            padding: 0.25rem 0.5rem;
+            font-size: 0.875rem;
+            border-radius: 0;
+            color: #fff;
+            background-color: #{$color};
+            border-color: #{$color};
+        }
     }
 }
+
+$colors: (
+    warning: $orange,
+    danger: $red,
+    success: $green,
+    info: $blue
+);
+
+@each $name,
+$color in $colors {
+    .badge-#{$name} {
+         --badge-color: #{$color};
+    }
+    .btn-badge-#{$name} {
+        button.btn {
+            padding: 0.25rem 0.5rem;
+            font-size: 0.875rem;
+            border-radius: 0;
+            color: #fff;
+            background-color: #{$color};
+            border-color: #{$color};
+        }
+
+    }
+    .badge-#{$name} {
+        i {
+            font-size: 20px;
+            overflow: hidden;
+            line-height: 0;
+            height: 0;
+            position: relative;
+            top: 3px;
+            right: 3px;
+            border-color: #{$color};
+        }
+    }
+}
+


### PR DESCRIPTION
Se implementó el uso de íconos y botones adjuntos a un plex-badge;
Ejemplos de uso:

**plex-badge + plex-button**
```
<plex-badge size="sm" type="warning">TEMPORAL
       <plex-button icon="clock"></plex-button>
 </plex-badge>
```

![image](https://user-images.githubusercontent.com/11394455/74739954-af3edc00-5238-11ea-87ae-5e55277bea4e.png)

------

**plex-badge + plex-icon**
```
<plex-badge size="sm" type="success">VALIDADO
        <plex-icon name="clock"></plex-icon>
</plex-badge>
```

![image](https://user-images.githubusercontent.com/11394455/74740130-0d6bbf00-5239-11ea-8877-4167ff51ec00.png)

------

**plex-badge + plex-button + plex-icon**
```
<plex-badge size="sm" type="success">VALIDADO
      <plex-icon name="clock"></plex-icon>
      <plex-button icon="clock"></plex-button>
</plex-badge>
```

![image](https://user-images.githubusercontent.com/11394455/74740236-4015b780-5239-11ea-913e-7be261de3fe6.png)

