### PR TITLE
PLEX: fix(plex-dropdown): estilo active con color de paleta plex

### DIFF
--- a/src/lib/css/plex-dropdown.scss
+++ b/src/lib/css/plex-dropdown.scss
@@ -1,4 +1,4 @@
 .dropdown-item {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
 }

--- a/src/lib/css/variables.scss
+++ b/src/lib/css/variables.scss
@@ -22,6 +22,10 @@ $brand-inverse: $dark-blue;
 // Body
 $body-bg: #e6e6e6;
 
+
+// Dropdown
+$dropdown-link-active-bg: $blue;
+
 // Font
 $font-family: 'TypoPRO Source Sans Pro';
 $font-family-sans-serif: 'TypoPRO Source Sans Pro';


### PR DESCRIPTION
El item seleccionado en un dropdown usaba un color heredado de bootstrap (blue primary) en lugar de usar el blue de la paleta de plex.
Ahora usa el blue default de andes (usado por los componentes con type="info")