### PR TITLE
fix(plex-modal): se agrega control para no bloquear teclas 

### DIFF
--- a/src/lib/modal/modal.component.ts
+++ b/src/lib/modal/modal.component.ts
@@ -49,7 +49,8 @@ export class PlexModalComponent {
 
     @HostListener('document:keydown', ['$event'])
     handleKeyboardEvent(event: KeyboardEvent) {
-        if (!this.showed) {
+        // Nos aseguramos de no bloquear el teclado si el usuario está escribiendo (isComposing)
+        if (event['isComposing'] && !this.showed) {
             return false;
         }
         if (event.which === 27) {


### PR DESCRIPTION
**Problema:**
Un plex-modal se puede cerrar tanto con un botón Cancelar como apretando la tecla ESC, en este úlitmo caso, se detectan eventos de teclado para realizar la acción.
Había un problema con la captura de eventos de teclado, ya que lo hacía de manera global y evitaba que, por ejemplo, se pueda escribir dentro de un plex-text.

**Solución**
Se agregó un control para asegurarse de que la detección de la tecla ESC suceda sólo después de que el usuario ya ingresó un caracter.