### PR TITLE
fix(plex-accordion):visualización invert

### DIFF
--- a/src/demo/app/accordion/accordion.html
+++ b/src/demo/app/accordion/accordion.html
@@ -1,4 +1,4 @@
-<plex-layout>
+<plex-layout main="8">
     <plex-layout-main>
         <plex-accordion>
             <plex-panel (toggle)="toggle($event)" active="true">
@@ -24,4 +24,29 @@
             </plex-panel>
         </plex-accordion>
     </plex-layout-main>
+    <plex-layout-sidebar type="invert">
+        <plex-accordion>
+            <plex-panel (toggle)="toggle($event)" active="true">
+                <div plex-accordion-title>
+                    Título con elementos html
+                    <plex-bool [(ngModel)]="test" type="slide" label="¿Está activo?" name="activo"
+                               (change)="bool($event)">
+                    </plex-bool>
+                </div>
+                <ng-container *ngIf="test">
+                    TOOGLE ACTIVE
+                </ng-container>
+                <ng-container *ngIf="!test">
+                    TOOGLE INACTIVE
+                </ng-container>
+            </plex-panel>
+            <plex-panel icon="history" tituloPrincipal="Título con ícono">
+                SEGUNDO PANEL
+            </plex-panel>
+            <plex-panel icon="youtube" tituloPrincipal="Video embebido" tituloSecundario="Psychocandy!">
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/iFp7W3PoNPI?ecver=1" frameborder="0"
+                        allowfullscreen></iframe>
+            </plex-panel>
+        </plex-accordion>
+    </plex-layout-sidebar>
 </plex-layout>

--- a/src/lib/css/plex-accordion.scss
+++ b/src/lib/css/plex-accordion.scss
@@ -5,6 +5,12 @@ plex-accordion {
     padding: .75rem 1.25rem;
   }
 
+  h5 a span{      
+    &:hover, :focus {
+      color: $blue;
+    }
+  }
+
   h5.item-title {
     display: inline-block;
     font-weight: 400;
@@ -20,7 +26,6 @@ plex-accordion {
   }
 
   // PANEL COLAPSADO
-
   .panel-default {
     background-color: #fff;
     border: solid 1px $dark-grey;
@@ -64,5 +69,12 @@ plex-accordion {
     border-top: solid 1px $dark-grey;
     border-radius: 0;
     padding: 20px;
+  }
+}
+
+// INVERT
+plex-layout-sidebar[type=invert] {
+  .card, .card-header {
+    border-color: white!important;
   }
 }

--- a/src/lib/css/variables.scss
+++ b/src/lib/css/variables.scss
@@ -139,3 +139,7 @@ label {
         text-transform: uppercase;
     }
 }
+
+// Accordion
+$card-bg: transparent;
+$card-cap-bg: var(--heading-background-color);


### PR DESCRIPTION
- Se transparenta background de componente para correcta visualización sobre fondo oscuro (invert)
- Se cambia color de bordes a blanco para su visualización en <plex-layout-sidebar type="invert">
- Se modifica demo para ver caso de uso