### PR TITLE
feat(plex-tab): Se optimiza uso de espacio de tab cuando tiene ícono

### DIFF
--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -35,7 +35,7 @@
 	</plex-layout-main>
 	<plex-layout-sidebar>
 		<plex-tabs size="full">
-			<plex-tab label="Buscador" color="procedimiento">
+			<plex-tab icon="account" label="Buscador" color="procedimiento">
 				<div class="alert alert-info">
 					Contenido 1
 				</div>

--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -1,39 +1,55 @@
 <plex-layout main="8">
 	<plex-layout-main>
-		<fieldset>
-			<legend>Tabs estático</legend>
-			<plex-tabs [activeIndex]="activo" (change)="cambio($event)">
-				<plex-tab label="Tab 1" color="procedimiento">
-					<div class="alert alert-info">
-						Contenido 1
-					</div>
-				</plex-tab>
-				<plex-tab *ngIf="mostrar" label="Tab 2" icon="account">
-					<div class="alert alert-warning">
-						Contenido 2
-					</div>
-				</plex-tab>
-				<plex-tab icon="history">
-					<div class="alert alert-danger">
-						Contenido 3
-					</div>
-				</plex-tab>
-			</plex-tabs>
-			<pre>Tab activo: {{activo}}</pre>
+		<plex-title titulo="Tabs estáticos">
 			<plex-button (click)="next()" label="Siguiente tab"></plex-button>
-		</fieldset>
-		<fieldset>
-			<legend>Tabs dinámico</legend>
-			<plex-tabs [activeIndex]="activoDinamico" (close)="close($event)">
-				<plex-tab *ngFor="let item of tabs" [label]="item.label" [icon]="item.icon" [color]="item.color" [allowClose]="true">
-					<div class="alert alert-warning">
-						Este es el contenido de <strong>{{item.label}}</strong>
-					</div>
-				</plex-tab>
-			</plex-tabs>
+		</plex-title>
+		<pre>Tab activo: {{activo}}</pre>
+		<plex-tabs [activeIndex]="activo" (change)="cambio($event)">
+			<plex-tab label="Tab 1" color="procedimiento">
+				<div class="alert alert-info">
+					Contenido 1
+				</div>
+			</plex-tab>
+			<plex-tab *ngIf="mostrar" label="Tab 2" icon="account">
+				<div class="alert alert-warning">
+					Contenido 2
+				</div>
+			</plex-tab>
+			<plex-tab icon="history">
+				<div class="alert alert-danger">
+					Contenido 3
+				</div>
+			</plex-tab>
+		</plex-tabs>
+		<plex-title titulo="Tabs dinámicos">
 			<plex-button (click)="add()" label="Agregar" type="success"></plex-button>
-		</fieldset>
+		</plex-title>
+		<plex-tabs [activeIndex]="activoDinamico" (close)="close($event)">
+			<plex-tab *ngFor="let item of tabs" [label]="item.label" [icon]="item.icon" [color]="item.color"
+					  [allowClose]="true">
+				<div class="alert alert-warning">
+					Este es el contenido de <strong>{{item.label}}</strong>
+				</div>
+			</plex-tab>
+		</plex-tabs>
 	</plex-layout-main>
 	<plex-layout-sidebar>
+		<plex-tabs size="full">
+			<plex-tab label="Buscador" color="procedimiento">
+				<div class="alert alert-info">
+					Contenido 1
+				</div>
+			</plex-tab>
+			<plex-tab label="Historia de Salud">
+				<div class="alert alert-warning">
+					Contenido 2
+				</div>
+			</plex-tab>
+			<plex-tab icon="file-tree">
+				<div class="alert alert-danger">
+					Contenido 3
+				</div>
+			</plex-tab>
+		</plex-tabs>
 	</plex-layout-sidebar>
 </plex-layout>

--- a/src/lib/css/plex-tabs.scss
+++ b/src/lib/css/plex-tabs.scss
@@ -20,6 +20,9 @@ $plex-tabs-color-extend: (
             width: 100%;
         }
     }
+    & .icon {
+        max-width: 50px;
+    }
 
     .nav-item {
         margin-bottom: -7px;

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -4,7 +4,7 @@ import { PlexTabComponent } from './tab.component';
 @Component({
     selector: 'plex-tabs',
     template: ` <ul #container class="nav nav-tabs" [ngClass]="size">
-                    <li *ngFor="let tab of tabs" (click)="selectTab(tab)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{active: tab.active}">
+                    <li *ngFor="let tab of tabs" (click)="selectTab(tab)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
                         <a class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
                             <i *ngIf="tab.icon" class="mdi mdi-{{tab.icon}}"></i>
                             <span *ngIf="tab.label">


### PR DESCRIPTION
Se aplicó una mejora de visualización para espacios reducidos cuando los tabs usan la opción size="full" y algún tab sólo tiene icono y no tiene label.

Ver adjunto:

![plex-tab-icon](https://user-images.githubusercontent.com/11394455/78051019-7c1d5b80-7353-11ea-997c-64a0f62826f6.png)
