### PR TITLE
fix(plex-help): se corrige overflow de contenido en resoluciones bajas

### DIFF
--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -5,7 +5,7 @@
             <plex-button size="sm" type="danger">ELIMINAR TODO</plex-button>
             <plex-help icon="information" titulo="Información sobre este módulo"
                        subtitulo="A continuación todas las opciones">
-                <ol info class="list-group-flush" *tpl>
+                <ol info class="list-group-flush">
                     <li class="list-group-item">Buscá conceptos SNOMED en el campo de texto del panel lateral
                         (acepta búsquedas
                         parciales)</li>

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -87,7 +87,7 @@ plex-help {
             right: 15px;
             top: 23px;
             z-index: 1001;
-            width: max-content;
+            width: auto;
             border-radius: 0.25rem;
             box-shadow: 2px 2px 5px 0px $dark-grey;
             max-height: 69vh;

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -90,6 +90,7 @@ plex-help {
             width: auto;
             border-radius: 0.25rem;
             box-shadow: 2px 2px 5px 0px $dark-grey;
+            min-width: 41vw;
             max-height: 69vh;
             overflow-y: scroll;
         }


### PR DESCRIPTION
El uso de `width: max-content` en plex-help **causa un problema** en la ventana flotante, haciendo que sea del ancho máximo que el contenido puede tener, lo cual trae problemas si el contenido es muy ancho, especialmente en resoluciones bajas (generalmente en monitores viejos o pequeños).
**Se solucionó** aplicando `width: auto`. Se descartó usar `fit-content` porque da un resultado demasiado ajustado.

![plex-help-max-content](https://user-images.githubusercontent.com/11394455/78263683-acdacd80-74d8-11ea-82ee-7a51d0d94766.png)

