### PR TITLE
feat(plex-badge): soporte para plex-datetime

### DIFF
--- a/src/demo/app/datetime/datetime.component.ts
+++ b/src/demo/app/datetime/datetime.component.ts
@@ -9,6 +9,7 @@ export class DateTimeDemoComponent implements OnInit {
     public model3: any;
     public model4: any;
     public tModel: any;
+    badgeModel: { fecha: any; };
 
     ngOnInit() {
         // Tepmlate-Form1 model
@@ -28,6 +29,10 @@ export class DateTimeDemoComponent implements OnInit {
         this.model4 = {
             fechaHora: null,
             disabled: true
+        };
+
+        this.badgeModel = {
+            fecha: moment(),
         };
     }
 

--- a/src/demo/app/datetime/datetime.html
+++ b/src/demo/app/datetime/datetime.html
@@ -3,6 +3,19 @@
         <form #form="ngForm">
             <div class="row">
                 <div class="col-md-6">
+                    <plex-title size="sm" titulo="Integrado con plex-badge">
+                        <plex-badge size="sm" type="info">{{ badgeModel.fecha | date: 'dd/MM/yyyy' }}
+                            <plex-datetime type="date" [(ngModel)]="badgeModel.fecha" name="onlybtn" required
+                                           [btnOnly]="true" size="sm">
+                            </plex-datetime>
+                        </plex-badge>
+                    </plex-title>
+                    <plex-badge size="sm" type="warning">{{ badgeModel.fecha | date: 'dd/MM/yyyy' }}
+                        <plex-datetime type="date" [(ngModel)]="badgeModel.fecha" name="onlybtn" required
+                                       [btnOnly]="true" size="sm">
+                        </plex-datetime>
+                    </plex-badge>
+
                     <plex-datetime label="Ingrese la fecha y la hora del evento" [(ngModel)]="tModel.fechaHora"
                                    name="fechaHora" required>
                     </plex-datetime>
@@ -22,12 +35,13 @@
                                    [readonly]="model4.disabled">
                     </plex-datetime>
 
-
                     <plex-button label="Actualizar maxHora" (click)="updateMaxHora()"></plex-button>
                     <plex-datetime label="Fecha con navegación inline (por dia)" [skipBy]="'day'"
                                    [(ngModel)]="tModel.fecha" [min]="tModel.min" [max]="tModel.max" name="fechaSkip"
                                    required>
                     </plex-datetime>
+
+
                 </div>
                 <div class="col-md-6">
                     <label>Modelo</label>

--- a/src/lib/badge/badge.component.ts
+++ b/src/lib/badge/badge.component.ts
@@ -9,6 +9,7 @@ import { Component, Input, ElementRef, ViewChild, OnChanges } from '@angular/cor
         </span>
         <span #badgeBtn class="btn-badge btn-badge-{{ type }}">
             <ng-content select="plex-button"></ng-content>
+            <ng-content select="plex-datetime"></ng-content>
         </span>
         `,
 })

--- a/src/lib/css/plex-badge.scss
+++ b/src/lib/css/plex-badge.scss
@@ -23,84 +23,92 @@
 
 }
 
-.badge {
-    @extend %baseBadge;
-}
-
-
-.btn-badge {
-    button.btn {
-        padding: 0.25rem 0.5rem;
-        font-size: 0.875rem;
-        border-radius: 0;
-        color: #fff;
-        background-color: var(--badge-color);
-        border-color: var(--badge-color);
-        &:hover {
-            background-color: var(--badge-color);
-            mix-blend-mode: darken;
-            opacity: .75;
-        }
+// Para integración de plex-datetime dentro de un plex-badge
+plex-badge {
+    display: inline-flex;
+    align-items: flex-end;
+    plex-datetime {
+        display: inline-flex;
     }
 
-}
-
-// Espaciado del ícono
-[class^="badge-"]>i,
-[class^="label-"]>i {
-    margin-right: 5px;
-}
-
-$colors: (
-    warning: $orange,
-    danger: $red,
-    success: $green,
-    info: $blue,
-    default: $dark-grey
-);
-
-@each $name, $color in $colors {
-    
-    .badge-#{$name} {
-        --badge-color: #{$color};
-        // Compatibilidad con andes hasta que se haga el refactor a plex-badge
+    .badge {
         @extend %baseBadge;
-        .btn {
-            @include button-factory($color);
-            position: relative;
-            right: 2px;
-        }
     }
-    
-    .btn-badge-#{$name} {
-        --badge-color: #{$color};
-        .btn {
-            @include button-factory($color);
-            position: relative;
-            right: 2px;
+
+    .btn-badge {
+        button.btn {
+            padding: 0.25rem 0.5rem;
+            font-size: 0.875rem;
+            border-radius: 0;
+            color: #fff;
+            background-color: var(--badge-color);
+            border-color: var(--badge-color);
+            &:hover {
+                background-color: var(--badge-color);
+                mix-blend-mode: darken;
+                opacity: .75;
+            }
         }
+
     }
-    
-}
+
+    // Espaciado del ícono
+    [class^="badge-"]>i,
+    [class^="label-"]>i {
+        margin-right: 5px;
+    }
+
+    $colors: (
+        warning: $orange,
+        danger: $red,
+        success: $green,
+        info: $blue,
+        default: $dark-grey
+    );
+
+    @each $name, $color in $colors {
+        .badge-#{$name} {
+            --badge-color: #{$color};
+            // Compatibilidad con andes hasta que se haga el refactor a plex-badge
+            @extend %baseBadge;
+            .btn {
+                @include button-factory($color);
+                position: relative;
+                right: 2px;
+            }
+        }
+        
+        .btn-badge-#{$name} {
+            --badge-color: #{$color};
+            .btn {
+                @include button-factory($color);
+                position: relative;
+                right: 2px;
+            }
+        }
+        
+    }
 
 
-/** BADGE EXTENSIBLE DESDE AFUERA DE PLEX */
-$badge-extend: () !default;
+    /** BADGE EXTENSIBLE DESDE AFUERA DE PLEX */
+    $badge-extend: () !default;
 
-@each $name, $color in $badge-extend {
-    .badge-#{$name} {
-        --badge-color: #{$color};
-        .btn {
-            @include button-factory($color);
-            position: relative;
-            right: 2px;
+    @each $name, $color in $badge-extend {
+        .badge-#{$name} {
+            --badge-color: #{$color};
+            .btn {
+                @include button-factory($color);
+                position: relative;
+                right: 2px;
+            }
+        }
+        .btn-badge-#{$name} {
+            .btn {
+                @include button-factory($color);
+                position: relative;
+                right: 2px;
+            }
         }
     }
-    .btn-badge-#{$name} {
-        .btn {
-            @include button-factory($color);
-            position: relative;
-            right: 2px;
-        }
-    }
+
 }

--- a/src/lib/css/plex-badge.scss
+++ b/src/lib/css/plex-badge.scss
@@ -30,85 +30,85 @@ plex-badge {
     plex-datetime {
         display: inline-flex;
     }
+}
 
-    .badge {
-        @extend %baseBadge;
-    }
+.badge {
+    @extend %baseBadge;
+}
 
-    .btn-badge {
-        button.btn {
-            padding: 0.25rem 0.5rem;
-            font-size: 0.875rem;
-            border-radius: 0;
-            color: #fff;
+.btn-badge {
+    button.btn {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        border-radius: 0;
+        color: #fff;
+        background-color: var(--badge-color);
+        border-color: var(--badge-color);
+        &:hover {
             background-color: var(--badge-color);
-            border-color: var(--badge-color);
-            &:hover {
-                background-color: var(--badge-color);
-                mix-blend-mode: darken;
-                opacity: .75;
-            }
-        }
-
-    }
-
-    // Espaciado del ícono
-    [class^="badge-"]>i,
-    [class^="label-"]>i {
-        margin-right: 5px;
-    }
-
-    $colors: (
-        warning: $orange,
-        danger: $red,
-        success: $green,
-        info: $blue,
-        default: $dark-grey
-    );
-
-    @each $name, $color in $colors {
-        .badge-#{$name} {
-            --badge-color: #{$color};
-            // Compatibilidad con andes hasta que se haga el refactor a plex-badge
-            @extend %baseBadge;
-            .btn {
-                @include button-factory($color);
-                position: relative;
-                right: 2px;
-            }
-        }
-        
-        .btn-badge-#{$name} {
-            --badge-color: #{$color};
-            .btn {
-                @include button-factory($color);
-                position: relative;
-                right: 2px;
-            }
-        }
-        
-    }
-
-
-    /** BADGE EXTENSIBLE DESDE AFUERA DE PLEX */
-    $badge-extend: () !default;
-
-    @each $name, $color in $badge-extend {
-        .badge-#{$name} {
-            --badge-color: #{$color};
-            .btn {
-                @include button-factory($color);
-                position: relative;
-                right: 2px;
-            }
-        }
-        .btn-badge-#{$name} {
-            .btn {
-                @include button-factory($color);
-                position: relative;
-                right: 2px;
-            }
+            mix-blend-mode: darken;
+            opacity: .75;
         }
     }
 
 }
+
+// Espaciado del ícono
+[class^="badge-"]>i,
+[class^="label-"]>i {
+    margin-right: 5px;
+}
+
+$colors: (
+    warning: $orange,
+    danger: $red,
+    success: $green,
+    info: $blue,
+    default: $dark-grey
+);
+
+@each $name, $color in $colors {
+    .badge-#{$name} {
+        --badge-color: #{$color};
+        // Compatibilidad con andes hasta que se haga el refactor a plex-badge
+        @extend %baseBadge;
+        .btn {
+            @include button-factory($color);
+            position: relative;
+            right: 2px;
+        }
+    }
+    
+    .btn-badge-#{$name} {
+        --badge-color: #{$color};
+        .btn {
+            @include button-factory($color);
+            position: relative;
+            right: 2px;
+        }
+    }
+    
+}
+
+
+/** BADGE EXTENSIBLE DESDE AFUERA DE PLEX */
+$badge-extend: () !default;
+
+@each $name, $color in $badge-extend {
+    .badge-#{$name} {
+        --badge-color: #{$color};
+        .btn {
+            @include button-factory($color);
+            position: relative;
+            right: 2px;
+        }
+    }
+    .btn-badge-#{$name} {
+        .btn {
+            @include button-factory($color);
+            position: relative;
+            right: 2px;
+        }
+    }
+}
+


### PR DESCRIPTION
Actualmente en un `plex-badge` pueden incluirse un `plex-button` o un `plex-icon` (o ambos), ahora se agregó soporte para `plex-datetime`:

```javascript
let myModel = {
        fecha: moment(),
};
```
```html
<plex-badge size="sm" type="warning">
    {{ myModel.fecha | date: 'dd/MM/yyyy' }}
    <plex-datetime type="date" [(ngModel)]="myModel.fecha" name="onlybtn" [btnOnly]="true" size="sm"></plex-datetime>
</plex-badge>
```
