### PR TITLE
fix(plex-detail):se corrige margen e/ info principal y labels

### DIFF
--- a/cypress/integration/detail.js
+++ b/cypress/integration/detail.js
@@ -1,0 +1,23 @@
+/// <reference types="Cypress" />
+
+context('detail', () => {
+    before(() => {
+        cy.eyesOpen({ appName: 'PLEX', testName: 'plex-detail' });
+        cy.visit('/detail');
+    });
+
+    it('test accordion', () => {
+        cy.eyesCheckWindow('plex-detail - main');
+
+        cy.get('plex-layout-sidebar .plex-box-content').scrollTo('bottom');
+
+        cy.eyesCheckWindow('plex-detail - scrool');
+
+        cy.get('plex-layout plex-help').click();
+
+        cy.eyesCheckWindow('plex-detail - plex-help');
+
+        cy.eyesClose();
+
+    });
+});

--- a/src/demo/app/detail/detail.html
+++ b/src/demo/app/detail/detail.html
@@ -6,6 +6,8 @@
                     <plex-detail direction="column" justify="center">
                         <img src="{{ paciente.foto }}" alt="">
                         <plex-badge size="xs">{{ paciente.estado }}</plex-badge>
+                        <plex-badge size="xs">{{ paciente.estado }}</plex-badge>
+                        <plex-badge size="xs">{{ paciente.estado }}</plex-badge>
                         <div title>{{ paciente.nombreCompleto }}</div>
                         <div subtitle>{{ paciente.documento }}</div>
                         <plex-label titulo="Fecha de Nacimiento" subtitulo="09/03/1990"></plex-label>
@@ -52,8 +54,10 @@
         </plex-title>
 
         <plex-title titulo="plex detail con imagen" size="sm"></plex-title>
-        <plex-detail size="md">
+        <plex-detail size="lg">
             <img src="{{ paciente.foto }}" alt="">
+            <plex-badge size="lg">{{ paciente.estado }}</plex-badge>
+            <plex-badge size="lg">{{ paciente.estado }}</plex-badge>
             <plex-badge size="lg">{{ paciente.estado }}</plex-badge>
             <div title> {{ paciente.nombreCompleto }} </div>
             <div subtitle> {{ paciente.documento }} </div>

--- a/src/lib/css/plex-detail.scss
+++ b/src/lib/css/plex-detail.scss
@@ -21,12 +21,13 @@ plex-detail {
         --detail-img-mr: 0;
         --detail-img-mb: 1rem;
         --detail-text-align: center;
+        --detail-badge-align: center;
     }
 
     section.direction-row {
         --detail-divider-align: start; 
         --detail-img-mr: 0.75rem;
-        --detail-img-mb: 0;
+        --detail-img-mb: 1rem;
         --detail-text-align: left;
 
         .contenedor-textos {
@@ -45,6 +46,10 @@ plex-detail {
         flex-direction: column;
         justify-content: center;
         text-align: center;
+
+        span {
+            justify-content: var(--detail-badge-align);
+        }
     }
     
     section.direction-row:first-child {
@@ -106,6 +111,7 @@ plex-detail {
             margin: 0.75rem 0;
             width: 25px;
             border: solid 1px $blue;
+            background: $blue;
             align-self: var(--detail-divider-align);
         }
     }

--- a/src/lib/detail/detail.component.ts
+++ b/src/lib/detail/detail.component.ts
@@ -10,7 +10,9 @@ import { PlexLabelComponent } from '../label/label.component';
                 <ng-content select="img"></ng-content>
             </div>
             <div class="contenedor-textos" [ngClass]="{ 'd-flex flex-column': direction === 'column'  }">
-                <ng-content select="plex-badge"></ng-content>
+                <span class="d-flex flex-row">
+                    <ng-content select="plex-badge"></ng-content>
+                </span>
                 <ng-content select="div[title]"></ng-content>
                 <ng-content select="div[subtitle]"></ng-content>
                 <hr>


### PR DESCRIPTION
**Problema:**
Al reducirse el tamaño de alguno de los elementos que componen el contenedor principal (título, subtítulo e imágen), el contenedor de los labels se "pega" al principal. 

**Solución:**
Se le asigna un valor de 1rem al márgen inferior de la imágen/icono

**Tareas scout:**
- Se alinean los badge al centro en la disposición 'column' (en un plex-help por ejemplo, antes se alineaban a la izq. > valor por defecto de flex)
- Se agrega 'background' a la línea divisora (antes presentaba un calado interno al tener sólo 'border')