### PR TITLE
fix(plex-select): nuevo hex value de loading icon

### DIFF
--- a/src/lib/css/plex-select.scss
+++ b/src/lib/css/plex-select.scss
@@ -527,12 +527,12 @@ $selectize-arrow-offset: $selectize-padding-x + 5px !default;
 .selectize-control.loading:before {
   color: $dark-grey;
   position: absolute;
-  right: 33px;
-  top: 2px;
+  right: 29px;
+  top: 3px;
   z-index: 10;
 
   font-family: "Material Design Icons";
-  content: "\F06A";
+  content: "\F0772";
   font-size: 1.4em;
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Se actualizó el icon que se muestra durante la carga de datos async de un plex-select.

![plex-select-output](https://user-images.githubusercontent.com/11394455/79462702-41135d00-7fce-11ea-9e2c-95597b873523.gif)

