### PR TITLE
feat(tooltip): se activa tooltip de material

### DIFF
--- a/cypress/integration/tooltip-hint.js
+++ b/cypress/integration/tooltip-hint.js
@@ -1,0 +1,26 @@
+context('tooltip & hint', () => {
+    before(() => {
+        cy.eyesOpen({ appName: 'PLEX', testName: 'tooltip-hint' });
+        cy.visit('/tooltip-hint');
+        cy.eyesCheckWindow('start - tooltip-hint');
+    });
+    after(() => {
+        cy.eyesCheckWindow('end - tooltip-hint');
+        cy.eyesClose();
+    });
+
+
+    it('title (tooltip) directive', () => {
+        const tooltipText = 'El tooltip es un texto que refuerza la acción a realizar';
+        cy.plexButton('tooltip').focus().tooltip(tooltipText).should('contain', tooltipText);
+        cy.plexButton('tooltip').blur();
+    });
+
+    it.only('hint directive', () => {
+        const hintText = '¿Sabías que... el hint es un texto que sugiere acciones o indica alguna novedad?';
+        cy.get('#cdk-describedby-message-container div').eq(0).should('not.be.visible');
+        cy.get('plex-hint').eq(0).find('a').focus().trigger('mouseover', { force: true });
+        cy.get('#cdk-describedby-message-container div').eq(0).should('contain', hintText);
+    });
+
+});

--- a/cypress/support/plex.js
+++ b/cypress/support/plex.js
@@ -269,6 +269,9 @@ Cypress.Commands.add('validationMessage', { prevSubject: true }, (subject, text)
     return cy.wrap(subject).find('div[class="form-control-feedback"]').should('contain', text);
 })
 
+Cypress.Commands.add('tooltip', { prevSubject: true }, (subject, text) => {
+    return cy.wrap(subject).parent().parent().find('.tooltip-inner').should('contain', text);
+});
 
 /**
  * @decrecated

--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -32,7 +32,7 @@ export class AppComponent implements OnInit {
             { label: 'Select', icon: 'format-list-bulleted', route: '/select' },
             { label: 'Tabs', icon: 'folder', route: '/tabs' },
             { label: 'Text', icon: 'alphabetical', route: '/text' },
-            { label: 'Tooltip', icon: 'tooltip', route: '/tooltip' },
+            { label: 'Tooltip & Hint', icon: 'tooltip', route: '/tooltip-hint' },
             { label: 'Wizard', icon: 'auto-fix', route: '/wizard' },
             { label: 'Wrapper', icon: 'view-quilt', route: '/wrapper' },
         ];

--- a/src/demo/app/app.module.ts
+++ b/src/demo/app/app.module.ts
@@ -49,6 +49,7 @@ import { MainListadoComponent } from './templates/listado-sidebar/main/listado/m
 import { ModalTemplateComponent } from './templates/componentes/plex-modal-template/plex-modal-template';
 import { DemoIconComponent } from './icon/icon';
 import { NavbarDemoComponent } from './navbar/navbar';
+import { TooltipHintDemoComponent } from './tooltip-hint/tooltip-hint.component';
 
 @NgModule({
     declarations: [
@@ -74,6 +75,7 @@ import { NavbarDemoComponent } from './navbar/navbar';
         DropdownDemoComponent,
         WizardDemoComponent,
         DemoIconComponent,
+        TooltipHintDemoComponent,
         TemplateFormComponent,
         TemplateVisualizacionComponent,
         TemplateBusquedaComponent,

--- a/src/demo/app/app.routes.ts
+++ b/src/demo/app/app.routes.ts
@@ -1,3 +1,4 @@
+import { TooltipHintDemoComponent } from './tooltip-hint/tooltip-hint.component';
 import { ModuleWithProviders } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { HomeDemoComponent } from './home/home.component';
@@ -52,6 +53,7 @@ const appRoutes: Routes = [
     { path: 'ribbon', component: RibbonDemoComponent },
     { path: 'phone', component: PhoneDemoComponent },
     { path: 'dropdown', component: DropdownDemoComponent },
+    { path: 'tooltip-hint', component: TooltipHintDemoComponent },
     { path: 'wizard', component: WizardDemoComponent },
     { path: 'templates/form', component: TemplateFormComponent },
     { path: 'templates/form-sidebar', component: TemplateBotoneraSidebarComponent },

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -1,11 +1,12 @@
 <plex-layout main="8">
     <plex-layout-main>
         <plex-title main justify titulo="Gestor de agendas">
-            <plex-badge size="sm" type="success">VALIDADO</plex-badge>
-            <plex-button size="sm" type="danger" title="
-            VALIDADO
-            Texto principal o titulo
-            Texto secundario intrisecamente relacionado al titulo" titlePosition="top">ELIMINAR TODO</plex-button>
+            <plex-badge size="sm" type="success">VALIDADO
+            </plex-badge>
+            <plex-button size="sm" type="danger" matTooltipPosition="right"
+                         matTooltip="Texto secundario intrisecamente relacionado al titulo" (click)="helpClick()">
+                ELIMINAR
+                TODO</plex-button>
             <plex-help icon="information" titulo="Información sobre este módulo"
                        subtitulo="A continuación todas las opciones">
                 <ol info class="list-group-flush">
@@ -77,7 +78,8 @@
     </plex-layout-main>
     <plex-layout-sidebar>
         <plex-title titulo="Texto principal" size="sm">
-            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="TOP">
+            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="TOP"
+                       matTooltip="Estaba la blanca paloma sentada en un verde limón, con el pico cortaba la rama como la rama cortaba la flor">
                 <ul class="list-group">
                     <li class="list-group-item active">Cras justo odio</li>
                     <li class="list-group-item">Dapibus ac facilisis in</li>
@@ -139,7 +141,8 @@
             <img src="https://www.prodapt.com/wp-content/uploads/user-icon.png" alt="" preview>
             <plex-badge type="info">Validado</plex-badge>
             <div title>Texto principal o titulo</div>
-            <div subtitle>Texto secundario intrisecamente relacionado al titulo</div>
+            <div subtitle>Texto secundario
+                intrisecamente relacionado al titulo</div>
         </plex-detail>
 
 

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -1,12 +1,15 @@
 <plex-layout main="8">
     <plex-layout-main>
         <plex-title main justify titulo="Gestor de agendas">
-            <plex-badge size="sm" type="success">VALIDADO
+            <plex-button size="sm" type="danger" tooltip="Texto secundario intrínsecamente...">
+                Tooltip 1
+            </plex-button>
+            <plex-button class="ml-1" size="sm" type="danger" tooltip="...relacionado al contenedor" position="above">
+                Tooltip 2
+            </plex-button>
+            <plex-badge class="ml-1" size="sm" type="success">VALIDADO
             </plex-badge>
-            <plex-button size="sm" type="danger" matTooltipPosition="above"
-                         matTooltip="Texto secundario intrínsecamente relacionado al título">
-                Tooltip 1</plex-button>
-            <plex-help icon="information" titulo="Información sobre este módulo"
+            <plex-help class="ml-1" icon="information" titulo="Información sobre este módulo"
                        subtitulo="A continuación todas las opciones">
                 <ol info class="list-group-flush">
                     <li class="list-group-item">Buscá conceptos SNOMED en el campo de texto del panel lateral
@@ -77,8 +80,8 @@
     </plex-layout-main>
     <plex-layout-sidebar>
         <plex-title titulo="Texto principal" size="sm">
-            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="Tooltip" matTooltipPosition="right"
-                       matTooltip="Estaba la blanca paloma sentada en un verde limón, con el pico cortaba la rama como la rama cortaba la flor">
+            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="Tooltip" position="right"
+                       tooltip="Estaba la blanca paloma sentada en un verde limón, con el pico cortaba la rama como la rama cortaba la flor">
                 <ul class="list-group">
                     <li class="list-group-item active">Cras justo odio</li>
                     <li class="list-group-item">Dapibus ac facilisis in</li>

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -1,12 +1,6 @@
 <plex-layout main="8">
     <plex-layout-main>
         <plex-title main justify titulo="Gestor de agendas">
-            <plex-button size="sm" type="danger" tooltip="Texto secundario intrínsecamente...">
-                Tooltip 1
-            </plex-button>
-            <plex-button class="ml-1" size="sm" type="danger" tooltip="...relacionado al contenedor" position="above">
-                Tooltip 2
-            </plex-button>
             <plex-badge class="ml-1" size="sm" type="success">VALIDADO
             </plex-badge>
             <plex-help class="ml-1" icon="information" titulo="Información sobre este módulo"
@@ -80,8 +74,7 @@
     </plex-layout-main>
     <plex-layout-sidebar>
         <plex-title titulo="Texto principal" size="sm">
-            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="Tooltip" position="right"
-                       tooltip="Estaba la blanca paloma sentada en un verde limón, con el pico cortaba la rama como la rama cortaba la flor">
+            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="Ayuda" position="right">
                 <ul class="list-group">
                     <li class="list-group-item active">Cras justo odio</li>
                     <li class="list-group-item">Dapibus ac facilisis in</li>

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -3,10 +3,9 @@
         <plex-title main justify titulo="Gestor de agendas">
             <plex-badge size="sm" type="success">VALIDADO
             </plex-badge>
-            <plex-button size="sm" type="danger" matTooltipPosition="right"
-                         matTooltip="Texto secundario intrisecamente relacionado al titulo" (click)="helpClick()">
-                ELIMINAR
-                TODO</plex-button>
+            <plex-button size="sm" type="danger" matTooltipPosition="above"
+                         matTooltip="Texto secundario intrínsecamente relacionado al título">
+                Tooltip 1</plex-button>
             <plex-help icon="information" titulo="Información sobre este módulo"
                        subtitulo="A continuación todas las opciones">
                 <ol info class="list-group-flush">
@@ -78,7 +77,7 @@
     </plex-layout-main>
     <plex-layout-sidebar>
         <plex-title titulo="Texto principal" size="sm">
-            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="TOP"
+            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="Tooltip" matTooltipPosition="right"
                        matTooltip="Estaba la blanca paloma sentada en un verde limón, con el pico cortaba la rama como la rama cortaba la flor">
                 <ul class="list-group">
                     <li class="list-group-item active">Cras justo odio</li>

--- a/src/demo/app/tooltip-hint/tooltip-hint.component.ts
+++ b/src/demo/app/tooltip-hint/tooltip-hint.component.ts
@@ -1,0 +1,10 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    templateUrl: './tooltip-hint.html'
+})
+export class TooltipHintDemoComponent implements OnInit {
+    constructor() { }
+
+    ngOnInit(): void { }
+}

--- a/src/demo/app/tooltip-hint/tooltip-hint.html
+++ b/src/demo/app/tooltip-hint/tooltip-hint.html
@@ -7,7 +7,7 @@
             <plex-button class="ml-1" size="sm" type="danger"
                          hint="¿Sabías que... el hint es un texto que sugiere acciones o indica alguna novedad?"
                          position="above">
-                hint 1
+                hint
             </plex-button>
         </plex-title>
         <main role="main" class="inner">
@@ -25,9 +25,11 @@
                 <li class="list-item">Brinda información extendida de un estado o situación</li>
                 <li class="list-item">Posee un "tip", una pequeña flecha que indica el elemento puntual de referencia
                 </li>
+                <li class="list-item">
+                    Para más opciones ver <a href="https://ui.andes.gob.ar/components/tooltip-directive/overview"
+                       target="_blank">la documentación oficial de tooltip</a>
+                </li>
             </ul>
-            Para más opciones ver <a href="https://ui.andes.gob.ar/components/tooltip-directive/overview"
-               target="_blank">la documentación oficial</a>.
             <hr>
             <b hint="¡Alerta! este es un tag &lt;b&gt;" icon="bell">Hint &nbsp;&nbsp;</b>
             <ul>
@@ -40,10 +42,11 @@
                 <li class="list-item">El texto complementario se visualiza en el evento onMouseOver sobre el ícono</li>
                 <li class="list-item">Según criterio, puede tener una función temporal, como indicar que hay una novedad
                 </li>
+                <li class="list-item">
+                    Para más opciones ver <a href="https://ui.andes.gob.ar/components/hint-directive/overview"
+                       target="_blank">la documentación oficial de hint</a>
+                </li>
             </ul>
-            Para más opciones ver <a href="https://ui.andes.gob.ar/components/hint-directive/overview"
-               target="_blank">la
-                documentación oficial</a>.
         </main>
     </plex-layout-main>
     <plex-layout-sidebar>

--- a/src/demo/app/tooltip-hint/tooltip-hint.html
+++ b/src/demo/app/tooltip-hint/tooltip-hint.html
@@ -1,11 +1,11 @@
 <plex-layout main="8">
     <plex-layout-main>
         <plex-title titulo="Directivas tooltip y hint">
-            <plex-button size="sm" type="danger" title="El tooltip es un texto que refuerza la acción a realizar">
+            <plex-button size="sm" type="danger" tooltip="El tooltip es un texto que refuerza la acción a realizar">
                 tooltip
             </plex-button>
             <plex-button class="ml-1" size="sm" type="danger"
-                         hint="¿Sabías que... el hint es un texto que sugiere acciones o indica alguna novedad?"
+                         hint="¿Sabías que... el hint es un texto que sugiere acciones o indica alguna novedad? Además tiene soporte multilínea."
                          position="above">
                 hint
             </plex-button>
@@ -17,12 +17,20 @@
             <b>Tooltip</b>
             <ul>
                 <li class="list-item">Se emplea sobre <a class="d-inline-block" href="tooltip-hint"
-                       title="Acción inofensiva">elementos de acción</a> o elementos iconográficos (por ej.: badges)
+                       title="Tooltip con directiva [title] (deprecated)">elementos de acción</a> o elementos
+                    iconográficos (por ej.: badges)
                 </li>
-                <li class="list-item">En estado de reposo es invisible, se activa en el evento onMouseOver</li>
+                <li class="list-item">En estado de reposo es <a class="d-inline-block" href="tooltip-hint"
+                       tooltip="Tooltip con directiva [tooltip]">invisible</a>, se activa en el evento onMouseOver</li>
                 <li class="list-item">No es multilínea</li>
                 <li class="list-item">Provee información complementaria acerca de una acción</li>
                 <li class="list-item">Brinda información extendida de un estado o situación</li>
+                <li class="list-item">Opcionalmente se puede indicar su posición (<a href="tooltip-hint"
+                       class="d-inline-block" tooltip="arriba" tooltipPosition="top">arriba</a>, <a href="tooltip-hint"
+                       class="d-inline-block" tooltip="abajo" tooltipPosition="bottom">abajo</a>, <a href="tooltip-hint"
+                       class="d-inline-block" tooltip="izquierda" titlePosition="left">izquierda</a> o <a
+                       href="tooltip-hint" class="d-inline-block" tooltip="derecha" titlePosition="right">derecha</a>)
+                </li>
                 <li class="list-item">Posee un "tip", una pequeña flecha que indica el elemento puntual de referencia
                 </li>
                 <li class="list-item">
@@ -31,11 +39,11 @@
                 </li>
             </ul>
             <hr>
-            <b hint="¡Alerta! este es un tag &lt;b&gt;" icon="bell">Hint &nbsp;&nbsp;</b>
+            <b hint="¡Alerta! estoy en un tag &lt;b&gt;" icon="bell">Hint &nbsp;&nbsp;</b>
             <ul>
                 <li class="list-item">Se emplea sobre cualquier elemento, sea o no de acción</li>
                 <li class="list-item">Sirve para indicar que hay alguna novedad o sugiere una funcionalidad</li>
-                <li class="list-item">Se puede usar a manera de "¡Sabías qué...?</li>
+                <li class="list-item">Se puede usar a manera de "¿Sabías qué...?</li>
                 <li class="list-item">Siempre visible como ícono flotante junto al elemento</li>
                 <li class="list-item">Tiene un ícono que lo identifica (default: help)</li>
                 <li class="list-item">Es multilínea</li>

--- a/src/demo/app/tooltip-hint/tooltip-hint.html
+++ b/src/demo/app/tooltip-hint/tooltip-hint.html
@@ -1,0 +1,64 @@
+<plex-layout main="8">
+    <plex-layout-main>
+        <plex-title titulo="Directivas tooltip y hint">
+            <plex-button size="sm" type="danger" title="El tooltip es un texto que refuerza la acción a realizar">
+                tooltip
+            </plex-button>
+            <plex-button class="ml-1" size="sm" type="danger"
+                         hint="¿Sabías que... el hint es un texto que sugiere acciones o indica alguna novedad?"
+                         position="above">
+                hint 1
+            </plex-button>
+        </plex-title>
+        <main role="main" class="inner">
+            <!-- <h4 class="cover-heading">Modals de Plex</h4> -->
+            <p class="lead">Las directivas <em>tooltip</em> y <em>hint</em> se usan como una ayuda contextual, tienen
+                similitudes y diferencias.</p>
+            <b>Tooltip</b>
+            <ul>
+                <li class="list-item">Se emplea sobre <a class="d-inline-block" href="tooltip-hint"
+                       title="Acción inofensiva">elementos de acción</a> o elementos iconográficos (por ej.: badges)
+                </li>
+                <li class="list-item">En estado de reposo es invisible, se activa en el evento onMouseOver</li>
+                <li class="list-item">No es multilínea</li>
+                <li class="list-item">Provee información complementaria acerca de una acción</li>
+                <li class="list-item">Brinda información extendida de un estado o situación</li>
+                <li class="list-item">Posee un "tip", una pequeña flecha que indica el elemento puntual de referencia
+                </li>
+            </ul>
+            Para más opciones ver <a href="https://ui.andes.gob.ar/components/tooltip-directive/overview"
+               target="_blank">la documentación oficial</a>.
+            <hr>
+            <b hint="¡Alerta! este es un tag &lt;b&gt;" icon="bell">Hint &nbsp;&nbsp;</b>
+            <ul>
+                <li class="list-item">Se emplea sobre cualquier elemento, sea o no de acción</li>
+                <li class="list-item">Sirve para indicar que hay alguna novedad o sugiere una funcionalidad</li>
+                <li class="list-item">Se puede usar a manera de "¡Sabías qué...?</li>
+                <li class="list-item">Siempre visible como ícono flotante junto al elemento</li>
+                <li class="list-item">Tiene un ícono que lo identifica (default: help)</li>
+                <li class="list-item">Es multilínea</li>
+                <li class="list-item">El texto complementario se visualiza en el evento onMouseOver sobre el ícono</li>
+                <li class="list-item">Según criterio, puede tener una función temporal, como indicar que hay una novedad
+                </li>
+            </ul>
+            Para más opciones ver <a href="https://ui.andes.gob.ar/components/hint-directive/overview"
+               target="_blank">la
+                documentación oficial</a>.
+        </main>
+    </plex-layout-main>
+    <plex-layout-sidebar>
+        <plex-title titulo="Hint con poco espacio">
+            <plex-help type="help" titulo="Ayuda de este panel" tituloBoton="Ayuda" position="right"
+                       hint="Para más ayuda sobre PLEX podés ir al sitio ui.andes.gob.ar">
+                <main role="main" class="inner px-2">
+                    <p class="lead mt-2">¡Hola!</p>
+                    <p> Soy el contenido de un plex-help. En este panel podés leer este mensaje.</p>
+                </main>
+            </plex-help>
+        </plex-title>
+        <main role="main" class="inner">
+            <!-- <h4 class="cover-heading">Modals de Plex</h4> -->
+            <p class="lead">El hint es multilínea, y se posiciona automáticamente según el espacio que tenga</p>
+        </main>
+    </plex-layout-sidebar>
+</plex-layout>

--- a/src/lib/css/hint.scss
+++ b/src/lib/css/hint.scss
@@ -23,6 +23,7 @@
 
         &:hover {
             background-color: $blue;
+            cursor: help;
         }
 
     }

--- a/src/lib/css/hint.scss
+++ b/src/lib/css/hint.scss
@@ -1,0 +1,29 @@
+.hint-container {
+
+    @include position(relative);
+    width: 0;
+    height: 18px;
+    display: inline-flex;
+
+    .hint {
+        font-size: 12px;
+        color: $light-blue;
+        background-color: $dark-grey;
+        border-radius: 9px;
+        padding: 1px 3px;
+        
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+
+        z-index: 1;
+    
+        // Position
+        @include position(relative, $bottom: 10px, $right: 10px);
+
+        &:hover {
+            background-color: $blue;
+        }
+
+    }
+}

--- a/src/lib/css/mixins/_position.scss
+++ b/src/lib/css/mixins/_position.scss
@@ -1,0 +1,7 @@
+@mixin position($pos: null, $top: null, $right: null, $bottom: null, $left: null) {
+    position: $pos;
+    top: $top;
+    right: $right;
+    bottom: $bottom;
+    left: $left;
+}

--- a/src/lib/css/nav.scss
+++ b/src/lib/css/nav.scss
@@ -10,6 +10,10 @@ nav {
   justify-content: space-between;
   height: $navbar-height;
 
+  &.fixed-top {
+    z-index: 1000;
+  }
+
   &.navbar-inverse.bg-info {
     background-color: var(--nav-bar-color) !important;
   }

--- a/src/lib/css/plex-title.scss
+++ b/src/lib/css/plex-title.scss
@@ -24,6 +24,9 @@
             font-size: 2em;
         }
     }
+    .title-content {
+        max-height: 26px;
+    }
 }
 
 header {

--- a/src/lib/css/tooltip.scss
+++ b/src/lib/css/tooltip.scss
@@ -1,0 +1,23 @@
+$tooltip-padding-y: .35rem;
+$tooltip-padding-x: .55rem;
+$border-radius: 4px;
+// $tooltip-bg: #616161;
+$tooltip-opacity: .7;
+$tooltip-arrow-color: #616161;
+
+.tooltip {
+
+    &.show { opacity: $tooltip-opacity; }
+
+    // Wrapper for the tooltip content
+    .tooltip-inner {
+        font-size: 11px;
+        max-width: $tooltip-max-width;
+        padding: $tooltip-padding-y $tooltip-padding-x;
+        color: $tooltip-color;
+        text-align: center;
+        background: $tooltip-bg;
+        @include border-radius($border-radius);
+        transition: ease-in;
+    }
+}

--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -3,15 +3,17 @@ import { Component, OnInit, AfterViewInit, Host, Self, Optional, Input, ElementR
 
 @Component({
     template: `
-        <span *ngIf="position" class="tooltip-hint-container" [matTooltip]="content" [matTooltipPosition]="position">
-            <plex-icon class="tooltip-hint" name="help" type="default"></plex-icon>
+        <span *ngIf="position" class="hint-container" [matTooltip]="content" [matTooltipPosition]="position">
+            <plex-icon class="hint" [name]="icon" type="default"></plex-icon>
         </span>
     `
 })
-export class TooltipHintComponent implements OnInit, AfterViewInit {
+export class HintComponent implements OnInit, AfterViewInit {
 
     @Input()
     hostElement: HTMLElement;
+
+    @Input() icon = 'help';
 
     @Input()
     content: string;
@@ -19,8 +21,6 @@ export class TooltipHintComponent implements OnInit, AfterViewInit {
     @Input() position = 'above';
 
     constructor(
-        @Optional() @Host() @Self() private matTooltip: MatTooltip,
-        private element: ElementRef,
         private cdr: ChangeDetectorRef) { }
 
     ngOnInit() {

--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -2,10 +2,11 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { Component, OnInit, AfterViewInit, Host, Self, Optional, Input, ElementRef, ChangeDetectorRef } from '@angular/core';
 
 @Component({
+    selector: 'plex-hint',
     template: `
-        <span *ngIf="position" class="hint-container" [matTooltip]="content" [matTooltipPosition]="position">
+        <a (click)="$event.preventImmediatePropagation()" href="javascript:void(0)" *ngIf="position" class="hint-container" [matTooltip]="content" [matTooltipPosition]="position">
             <plex-icon class="hint" [name]="icon" type="default"></plex-icon>
-        </span>
+        </a>
     `
 })
 export class HintComponent implements OnInit, AfterViewInit {

--- a/src/lib/hint/hint.directive.ts
+++ b/src/lib/hint/hint.directive.ts
@@ -1,14 +1,15 @@
 import { Directive, ComponentRef, ViewContainerRef, ComponentFactoryResolver, OnInit, Input, AfterViewInit, Host } from '@angular/core';
-import { TooltipHintComponent } from './tooltip-hint.component';
+import { HintComponent } from './hint.component';
 
 @Directive({
     // tslint:disable-next-line:directive-selector
-    selector: '[tooltip], [position:has(tooltip)]',
+    selector: '[hint], [position:has(hint)], [icon:has(hint)]',
 })
-export class TooltipHintDirective implements AfterViewInit {
+export class HintDirective implements AfterViewInit {
 
-    private tooltip: ComponentRef<TooltipHintComponent>;
-    @Input('tooltip') content: string | TooltipHintComponent;
+    private tooltip: ComponentRef<HintComponent>;
+    @Input('hint') content: string | HintComponent;
+    @Input() icon = 'help';
 
     @Input()
     set position(value: 'top' | 'right' | 'bottom' | 'left' | 'above' | 'below') {
@@ -28,11 +29,12 @@ export class TooltipHintDirective implements AfterViewInit {
 
     ngAfterViewInit(): void {
 
-        const factory = this.resolver.resolveComponentFactory(TooltipHintComponent);
+        const factory = this.resolver.resolveComponentFactory(HintComponent);
         this.tooltip = this.viewContainerRef.createComponent(factory);
         this.tooltip.instance.hostElement = this.viewContainerRef.element.nativeElement;
         this.tooltip.instance.content = this.content as string;
         this.tooltip.instance.position = this.position as string;
+        this.tooltip.instance.icon = this.icon;
 
     }
 

--- a/src/lib/icon/icon.component.ts
+++ b/src/lib/icon/icon.component.ts
@@ -7,7 +7,7 @@ import { Component, Input } from '@angular/core';
 export class PlexIconComponent {
     @Input() prefix = 'mdi';
     @Input() name: string;
-    @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'primary';
+    @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'default' = 'default';
     @Input() size: '18' | '24' | '36' | '48';
 
     constructor() {

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -67,6 +67,8 @@ import { SimpleNotificationsModule } from './toast/simple-notifications.module';
 import { ChartsModule } from 'ng2-charts';
 import { QuillModule } from 'ngx-quill';
 import { NavItemComponent } from './app/nav-item.component';
+import { TooltipHintComponent } from './tooltip-hint/tooltip-hint.component';
+import { TooltipHintDirective } from './tooltip-hint/tooltip-hint.directive';
 
 const MODULES = [
     PlexAppComponent,
@@ -96,12 +98,12 @@ const MODULES = [
     PlexLayoutMainComponent,
     PlexLayoutSidebarComponent,
     PlexWizardDirective,
-    TooltipComponent,
     PlexListComponent,
     PlexItemComponent,
     PlexLabelComponent,
     PlexHeadingComponent,
     PlexTitleComponent,
+    TooltipComponent,
     JustifyDirective,
     ResponsiveDirective,
     GrowDirective,
@@ -115,6 +117,7 @@ const MODULES = [
     PreviewDirective,
     NavItemComponent,
     PlexWrapperComponent,
+    TooltipHintDirective
     // MatTooltip
 ];
 
@@ -136,12 +139,15 @@ const MODULES = [
     declarations: [
         ...MODULES,
         ValidationMessagesComponent,
-        TooltipContentComponent
+        TooltipContentComponent,
+        TooltipHintComponent,
+
     ],
     entryComponents: [
         TooltipContentComponent,
         MatRadioButton,
-        PlexVisualizadorComponent
+        PlexVisualizadorComponent,
+        TooltipHintComponent
     ],
     exports: [
         ...MODULES,

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -67,8 +67,8 @@ import { SimpleNotificationsModule } from './toast/simple-notifications.module';
 import { ChartsModule } from 'ng2-charts';
 import { QuillModule } from 'ngx-quill';
 import { NavItemComponent } from './app/nav-item.component';
-import { TooltipHintComponent } from './tooltip-hint/tooltip-hint.component';
-import { TooltipHintDirective } from './tooltip-hint/tooltip-hint.directive';
+import { HintComponent } from './hint/hint.component';
+import { HintDirective } from './hint/hint.directive';
 
 const MODULES = [
     PlexAppComponent,
@@ -117,7 +117,7 @@ const MODULES = [
     PreviewDirective,
     NavItemComponent,
     PlexWrapperComponent,
-    TooltipHintDirective
+    HintDirective
     // MatTooltip
 ];
 
@@ -140,14 +140,14 @@ const MODULES = [
         ...MODULES,
         ValidationMessagesComponent,
         TooltipContentComponent,
-        TooltipHintComponent,
+        HintComponent,
 
     ],
     entryComponents: [
         TooltipContentComponent,
         MatRadioButton,
         PlexVisualizadorComponent,
-        TooltipHintComponent
+        HintComponent
     ],
     exports: [
         ...MODULES,

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -56,9 +56,11 @@ import { PreviewDirective } from './visualizador/preview.directive';
 import { ResponsiveDirective } from './directives/responsive.directive';
 
 // Third party
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatRadioModule, MatRadioButton } from '@angular/material/radio';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTooltipModule, MatTooltip } from '@angular/material/tooltip';
 import 'hammerjs';
 import * as configMoment from './core/configMoment.function';
 import { SimpleNotificationsModule } from './toast/simple-notifications.module';
@@ -112,7 +114,8 @@ const MODULES = [
     PlexVisualizadorComponent,
     PreviewDirective,
     NavItemComponent,
-    PlexWrapperComponent
+    PlexWrapperComponent,
+    // MatTooltip
 ];
 
 @NgModule({
@@ -120,13 +123,15 @@ const MODULES = [
         CommonModule,
         RouterModule,
         FormsModule,
+        BrowserAnimationsModule,
         MatSlideToggleModule,
         MatCheckboxModule,
         MatRadioModule,
+        MatTooltipModule,
         ChartsModule,
         QuillModule,
+        InfiniteScrollModule,
         SimpleNotificationsModule.forRoot(),
-        InfiniteScrollModule
     ],
     declarations: [
         ...MODULES,
@@ -137,9 +142,11 @@ const MODULES = [
         TooltipContentComponent,
         MatRadioButton,
         PlexVisualizadorComponent
-
     ],
-    exports: MODULES
+    exports: [
+        ...MODULES,
+        MatTooltip
+    ]
 })
 export class PlexModule {
     constructor() {

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -12,6 +12,7 @@
 @import "css/mixins/hover";
 @import "css/mixins/buttons";
 @import 'css/mixins/scrollbar';
+@import 'css/mixins/position';
 
 // Core CSS
 @import "node_modules/bootstrap/scss/reboot";
@@ -42,7 +43,7 @@
 @import "node_modules/bootstrap/scss/responsive-embed";
 @import "node_modules/bootstrap/scss/close";
 // Components w/ JavaScript
-@import "node_modules/bootstrap/scss/tooltip";
+// @import "node_modules/bootstrap/scss/tooltip";
 @import "node_modules/bootstrap/scss/popover";
 // Utility classes
 @import "node_modules/bootstrap/scss/utilities";

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -43,7 +43,7 @@
 @import "node_modules/bootstrap/scss/responsive-embed";
 @import "node_modules/bootstrap/scss/close";
 // Components w/ JavaScript
-// @import "node_modules/bootstrap/scss/tooltip";
+@import "node_modules/bootstrap/scss/tooltip";
 @import "node_modules/bootstrap/scss/popover";
 // Utility classes
 @import "node_modules/bootstrap/scss/utilities";
@@ -68,6 +68,8 @@ $mdi-font-path: '~@mdi/font/fonts/';
 @import 'css/fonts';
 @import 'css/forms';
 @import 'css/list-group';
+@import 'css/tooltip.scss';
+@import 'css/hint.scss';
 
 // Third party
 @import 'css/toast';

--- a/src/lib/title/title.component.ts
+++ b/src/lib/title/title.component.ts
@@ -5,7 +5,7 @@ import { Component, Input, Renderer } from '@angular/core';
     template: `
         <div class="plex-title d-flex flex-row justify-content-between align-items-center">
             <div class="plex-title-label {{ size }}"> {{ titulo }} </div>
-            <div>
+            <div class="title-content">
                 <ng-content></ng-content>
             </div>
         </div>

--- a/src/lib/tooltip-hint/tooltip-hint.component.ts
+++ b/src/lib/tooltip-hint/tooltip-hint.component.ts
@@ -1,0 +1,34 @@
+import { MatTooltip } from '@angular/material/tooltip';
+import { Component, OnInit, AfterViewInit, Host, Self, Optional, Input, ElementRef, ChangeDetectorRef } from '@angular/core';
+
+@Component({
+    template: `
+        <span *ngIf="position" class="tooltip-hint-container" [matTooltip]="content" [matTooltipPosition]="position">
+            <plex-icon class="tooltip-hint" name="help" type="default"></plex-icon>
+        </span>
+    `
+})
+export class TooltipHintComponent implements OnInit, AfterViewInit {
+
+    @Input()
+    hostElement: HTMLElement;
+
+    @Input()
+    content: string;
+
+    @Input() position = 'above';
+
+    constructor(
+        @Optional() @Host() @Self() private matTooltip: MatTooltip,
+        private element: ElementRef,
+        private cdr: ChangeDetectorRef) { }
+
+    ngOnInit() {
+        this.position = 'above';
+    }
+
+    ngAfterViewInit(): void {
+        this.cdr.detectChanges();
+    }
+
+}

--- a/src/lib/tooltip-hint/tooltip-hint.directive.ts
+++ b/src/lib/tooltip-hint/tooltip-hint.directive.ts
@@ -1,0 +1,39 @@
+import { Directive, ComponentRef, ViewContainerRef, ComponentFactoryResolver, OnInit, Input, AfterViewInit, Host } from '@angular/core';
+import { TooltipHintComponent } from './tooltip-hint.component';
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[tooltip], [position:has(tooltip)]',
+})
+export class TooltipHintDirective implements AfterViewInit {
+
+    private tooltip: ComponentRef<TooltipHintComponent>;
+    @Input('tooltip') content: string | TooltipHintComponent;
+
+    @Input()
+    set position(value: 'top' | 'right' | 'bottom' | 'left' | 'above' | 'below') {
+        if (value === 'top') {
+            this.position = 'above';
+        }
+        if (value === 'bottom') {
+            this.position = 'below';
+        }
+    }
+
+    constructor(
+        private viewContainerRef: ViewContainerRef,
+        private resolver: ComponentFactoryResolver
+    ) {
+    }
+
+    ngAfterViewInit(): void {
+
+        const factory = this.resolver.resolveComponentFactory(TooltipHintComponent);
+        this.tooltip = this.viewContainerRef.createComponent(factory);
+        this.tooltip.instance.hostElement = this.viewContainerRef.element.nativeElement;
+        this.tooltip.instance.content = this.content as string;
+        this.tooltip.instance.position = this.position as string;
+
+    }
+
+}

--- a/src/lib/tooltip/tooltip.component.ts
+++ b/src/lib/tooltip/tooltip.component.ts
@@ -4,7 +4,7 @@ import { TooltipContentComponent } from './tooltip-content.component';
 
 @Directive({
     // tslint:disable-next-line:directive-selector
-    selector: '[title]'
+    selector: '[tooltip],[title]'
 })
 // tslint:disable-next-line:directive-class-suffix
 export class TooltipComponent {
@@ -12,7 +12,7 @@ export class TooltipComponent {
     // Properties
     // -------------------------------------------------------------------------
 
-    private tooltip: ComponentRef<TooltipContentComponent>;
+    private tooltipComp: ComponentRef<TooltipContentComponent>;
     private visible: boolean;
 
     // -------------------------------------------------------------------------
@@ -21,7 +21,15 @@ export class TooltipComponent {
 
     // tslint:disable-next-line:no-input-rename
     @Input('title') content: string | TooltipContentComponent;
-    @Input() titlePosition: 'top' | 'bottom' | 'left' | 'right' = 'top';
+    @Input()
+    set tooltip(value: string | TooltipContentComponent) {
+        this.content = value;
+    }
+    @Input() tooltipPosition: 'top' | 'bottom' | 'left' | 'right' = 'top';
+    @Input()
+    set titlePosition(value: 'top' | 'bottom' | 'left' | 'right') {
+        this.tooltipPosition = value;
+    }
     @Input() tooltipDisabled: boolean;
     @Input() tooltipAnimation = false;
 
@@ -49,15 +57,15 @@ export class TooltipComponent {
                 return;
             }
 
-            this.tooltip = this.viewContainerRef.createComponent(factory);
-            this.tooltip.instance.hostElement = this.viewContainerRef.element.nativeElement;
-            this.tooltip.instance.content = this.content as string;
-            this.tooltip.instance.placement = this.titlePosition;
-            this.tooltip.instance.animation = this.tooltipAnimation;
+            this.tooltipComp = this.viewContainerRef.createComponent(factory);
+            this.tooltipComp.instance.hostElement = this.viewContainerRef.element.nativeElement;
+            this.tooltipComp.instance.content = this.content as string;
+            this.tooltipComp.instance.placement = this.tooltipPosition;
+            this.tooltipComp.instance.animation = this.tooltipAnimation;
         } else {
             const tooltip = this.content as TooltipContentComponent;
             tooltip.hostElement = this.viewContainerRef.element.nativeElement;
-            tooltip.placement = this.titlePosition;
+            tooltip.placement = this.tooltipPosition;
             tooltip.animation = this.tooltipAnimation;
             tooltip.show();
         }
@@ -71,8 +79,8 @@ export class TooltipComponent {
         }
 
         this.visible = false;
-        if (this.tooltip) {
-            this.tooltip.destroy();
+        if (this.tooltipComp) {
+            this.tooltipComp.destroy();
         }
 
         if (this.content instanceof TooltipContentComponent) {


### PR DESCRIPTION
Este tooltip no "compite" con el tooltip actual, con lo cual se podría simplemente reemplazar todas las ocurrencias de `title=""` y `[title]="" `en todas las apps que usen Plex.