### PR TITLE
feat(plex-options): se agregan clases para comportamiento responsivo

### DIFF
--- a/src/lib/css/plex-options.scss
+++ b/src/lib/css/plex-options.scss
@@ -1,0 +1,9 @@
+plex-options {
+    .options-container {
+        display: flex;        
+    }
+
+    .option-grow {
+        flex-grow: 1;
+    }
+}

--- a/src/lib/options/options.component.ts
+++ b/src/lib/options/options.component.ts
@@ -10,9 +10,9 @@ export interface IPlexOptionsItems {
     selector: 'plex-options',
     template: `
         <div class="row">
-            <div class="btn-group col">
+            <div class="d-flex col flex-wrap">
                 <ng-container *ngFor="let item of items">
-                    <button class="btn btn-primary btn-sm btn-block m-0" (click)="onOptionsClick(item)" [class.active]="active === item.key">
+                    <button class="btn btn-primary btn-sm option-grow m-0" (click)="onOptionsClick(item)" [class.active]="active === item.key">
                         {{ item.label }}
                     </button>
                 </ng-container>

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -94,5 +94,6 @@ $mdi-font-path: '~@mdi/font/fonts/';
 @import 'css/plex-help';
 @import 'css/plex-modal';
 @import 'css/plex-detail';
+@import 'css/plex-options';
 @import 'css/plex-visualizador';
-@import 'css/plex-wrapper.scss';
+@import 'css/plex-wrapper';


### PR DESCRIPTION
- Se flexea el contenedor de los la botonera interna del componente
- Se aplica un 'grow: 1' para lograr equidad de anchos y comportamiento full en caso de botón huérfano.