### PR TITLE
feat(plex-title): modo responsive de botonera

### DIFF
--- a/src/lib/css/plex-detail.scss
+++ b/src/lib/css/plex-detail.scss
@@ -165,7 +165,7 @@ plex-detail {
     }
 
         // size-xs
-    section.size-xs { 
+    section.size-md { 
         div.contenedor-elementos-graficos { 
             // se disminuyen las imagenes
             img {  

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -69,7 +69,7 @@ plex-help {
         position: initial;
         display: inline-block;
         min-width: 42px;
-        height: 33px;
+        height: auto;
         &.open {
             top: 0;
         }

--- a/src/lib/css/plex-title.scss
+++ b/src/lib/css/plex-title.scss
@@ -34,3 +34,15 @@ header {
         border-bottom: none !important;
     }
 }
+
+@include media-breakpoint-down(sm) {
+    .plex-title {
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        div:last-child {
+            width: 100%;
+            display: flex;
+            justify-content: space-between;
+        }
+    }
+}

--- a/src/lib/css/plex-title.scss
+++ b/src/lib/css/plex-title.scss
@@ -25,7 +25,13 @@
         }
     }
     .title-content {
-        max-height: 26px;
+        max-height: 36px;
+    }
+    &.size-sm {
+        flex-wrap: wrap;
+        .title-content {
+            justify-content: space-between;
+        }
     }
 }
 
@@ -35,14 +41,3 @@ header {
     }
 }
 
-@include media-breakpoint-down(sm) {
-    .plex-title {
-        flex-wrap: wrap;
-        justify-content: flex-end;
-        div:last-child {
-            width: 100%;
-            display: flex;
-            justify-content: space-between;
-        }
-    }
-}

--- a/src/lib/css/plex-wrapper.scss
+++ b/src/lib/css/plex-wrapper.scss
@@ -56,7 +56,7 @@ plex-wrapper  {
         flex: 0 0 190px;
     }
 
-    .size-xs {
+    .size-md {
         plex-datetime, plex-radio {
             flex: 1 0 190px;
         }

--- a/src/lib/directives/responsive.directive.ts
+++ b/src/lib/directives/responsive.directive.ts
@@ -14,16 +14,19 @@ export class ResponsiveDirective implements AfterViewChecked {
 
     checkDimension() {
         this.width = this.el.nativeElement.clientWidth;
-        this.render.removeClass(this.el.nativeElement, 'size-xs');
+        this.render.removeClass(this.el.nativeElement, 'size-sm');
         this.render.removeClass(this.el.nativeElement, 'size-md');
+        this.render.removeClass(this.el.nativeElement, 'size-lg');
         this.render.removeClass(this.el.nativeElement, 'size-xl');
 
         if (this.width >= 1024) {
             this.render.addClass(this.el.nativeElement, 'size-xl');
         } else if (this.width >= 768 && this.width < 1024) {
+            this.render.addClass(this.el.nativeElement, 'size-lg');
+        } else if (this.width >= 576 && this.width < 768) {
             this.render.addClass(this.el.nativeElement, 'size-md');
-        } else if (this.width < 768) {
-            this.render.addClass(this.el.nativeElement, 'size-xs');
+        } else if (this.width < 576) {
+            this.render.addClass(this.el.nativeElement, 'size-sm');
         }
     }
 

--- a/src/lib/title/title.component.ts
+++ b/src/lib/title/title.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, Renderer } from '@angular/core';
 @Component({
     selector: 'plex-title',
     template: `
-        <div class="plex-title d-flex flex-row justify-content-between align-items-center">
+        <div class="plex-title d-flex flex-row justify-content-between align-items-center" responsive>
             <div class="plex-title-label {{ size }}"> {{ titulo }} </div>
             <div class="title-content">
                 <ng-content></ng-content>


### PR DESCRIPTION
Se implementa una versión responsive inicial de plex-title.
Básicamente acomoda el título en una línea inicial, y el agrupamiento de elementos (botones, badges, etc) en la línea siguiente, con las siguientes reglas:
- El título se mantiene alineado a la izquierda
- Lo botones y elementos pasan de estar alineados a la derecha a tener la regla "space-between" de justificado de flex.

![plex-title-responsive](https://user-images.githubusercontent.com/11394455/83182864-603cf880-a0fd-11ea-8fb1-1577d90ba1d2.png)
