### PR TITLE
fix(plex-detail): se define ancho de nombres y wrapean los badges

### DIFF
--- a/src/lib/css/plex-detail.scss
+++ b/src/lib/css/plex-detail.scss
@@ -23,17 +23,17 @@ plex-detail {
         --detail-text-align: center;
         --detail-badge-align: center;
     }
-
+    
     section.direction-row {
         --detail-divider-align: start; 
         --detail-img-mr: 0.75rem;
         --detail-img-mb: 1rem;
         --detail-text-align: left;
-
+        
         .contenedor-textos {
+            width: fit-content;
             margin-right: 2rem;
         }
-
     }
 
     %baseDirection {

--- a/src/lib/detail/detail.component.ts
+++ b/src/lib/detail/detail.component.ts
@@ -10,7 +10,7 @@ import { PlexLabelComponent } from '../label/label.component';
                 <ng-content select="img"></ng-content>
             </div>
             <div class="contenedor-textos" [ngClass]="{ 'd-flex flex-column': direction === 'column'  }">
-                <span class="d-flex flex-row">
+                <span class="d-flex flex-row flex-wrap">
                     <ng-content select="plex-badge"></ng-content>
                 </span>
                 <ng-content select="div[title]"></ng-content>


### PR DESCRIPTION
**Problema:**
El contenedor donde se alojaba el nombre completo del paciente no tenía un valor asignado en la propiedad 'width'. Por lo que tomaba el valor 'auto', heredando el ancho máximo de su contenedor padre (de muy reducido tamaño).

**Solución**
Settear un valor 'fit-content' al contenedor e incluir un wrap para que los textos no excedan el ancho de su contenedor en pantallas reducidas. 
![detail-fix](https://user-images.githubusercontent.com/5895886/83419542-9929e580-a3fb-11ea-80e8-713e8984bc33.PNG)
