### PR TITLE
fix(plex-wrapper): se settea scrollbar en overlay

### DIFF
--- a/src/demo/app/templates/listado-sidebar/listado-sidebar.html
+++ b/src/demo/app/templates/listado-sidebar/listado-sidebar.html
@@ -1,4 +1,4 @@
-=<plex-layout main="8">
+<plex-layout main="8">
     <plex-layout-main>
         <plex-title size="lg" titulo="Bienvenido a Plex">
             <plex-help type="help" titulo="Ayuda de este panel" size="sm" title="este es un atributo [title]"

--- a/src/lib/css/plex-box.scss
+++ b/src/lib/css/plex-box.scss
@@ -15,10 +15,10 @@ plex-box > DIV {
 
     & > .plex-box-content {
         clear: both;
-        overflow-y: auto;
+        overflow-y: overlay;
         overflow-x: hidden; // expandir a todo el alto del contenedor
         flex: 1;
-        padding-right: 10px; // Distancia desde el scrollback
+        padding-right: 15px; // Distancia desde el scrollback
         height: 0;
         // Fix momentaneo
         .plex-box-content {

--- a/src/lib/wrapper/wrapper.component.ts
+++ b/src/lib/wrapper/wrapper.component.ts
@@ -5,8 +5,8 @@ import { Plex } from '../core/service';
     selector: 'plex-wrapper',
     template: `
     <section class="hidden" [class.desplegado]="desplegado" responsive>
-        <plex-button class="btn-toogle" type="info" size="sm" *ngIf="hasCollapse"
-                     [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toogle()">
+        <plex-button class="btn-toogle" type="info" size="sm" *ngIf="hasCollapse" 
+            [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toogle()">
         </plex-button>
         <ng-content></ng-content>
         <ng-content select="[collapse]"></ng-content>

--- a/src/lib/wrapper/wrapper.component.ts
+++ b/src/lib/wrapper/wrapper.component.ts
@@ -5,7 +5,7 @@ import { Plex } from '../core/service';
     selector: 'plex-wrapper',
     template: `
     <section class="hidden" [class.desplegado]="desplegado" responsive>
-        <plex-button class="btn-toogle" type="info" size="sm" *ngIf="hasCollapse" 
+        <plex-button class="btn-toogle" type="info" size="sm" *ngIf="hasCollapse"
             [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toogle()">
         </plex-button>
         <ng-content></ng-content>


### PR DESCRIPTION
**Problema**
Al aparecer el scrollbar, modifica el ancho del contenedor de los inputs y genera reconfiguración de los elementos.

**Solución**
Se cambia valor asignado al scroll, de 'auto' a 'overlay'; de éste modo, al aparecer el scrollbar no 'empuja' los elementos (inputs) hacia adentro provocando su reordenamiento y consecuente apilamiento (al estar el ancho cercano a un breakpoint).