### PR TITLE
fix(plex-item): se agrega versión sin botonera

### DIFF
--- a/src/lib/css/plex-item.scss
+++ b/src/lib/css/plex-item.scss
@@ -31,13 +31,11 @@ plex-list {
         grid-gap: .25rem;
         height: 40px;
         max-height: 40px;
-        width: 100%;
 
         &.sticky {
             position: sticky;
             top: 0;
             z-index: 10;
-            // background-color: var(--heading-background-color)!important;
         }
 
         >* {
@@ -229,11 +227,11 @@ plex-list {
     } 
     
     // Con botonera
-    .item-list.has-botonera {
+    .item-list {
         width: 100%;
     }
     
-    .item-list-heading.has-botonera {
+    .item-list-heading {
         width: 75%;
     }
     
@@ -259,7 +257,7 @@ plex-list {
 
     // Directiva responsive
     plex-list {
-        > div.size-xs {
+        > div.size-sm {
             
             section {
                 .item-list-heading {
@@ -278,7 +276,7 @@ plex-list {
                 div.item-list {
                     margin-top: .5rem;
                     grid-auto-flow: unset;
-                    width: 100%!important;
+                    // width: 100%!important;
                 }
         
                 .botonera {

--- a/src/lib/item-list/item.component.ts
+++ b/src/lib/item-list/item.component.ts
@@ -19,7 +19,7 @@ import { PlexButtonComponent } from '../button/button.component';
                 <div class="item-list"
                     [class.has-icon]="plexIcons?.length > 0 || imgs || svgs"
                     [class.has-checkbox]="plexBools?.length > 0"
-                    [class.has-botonera]="plexButtons?.length > 0 || plexBadges?.length > 0" >
+                    >
                     <ng-content></ng-content>
                 </div>
             </div>


### PR DESCRIPTION
**Problema:**
Para evitar desfase de heading respecto a columnas de listado cuando no había botones se incorporaban elementos HTML vacíos en el heading para compensar espacio y lograr el alineamiento de las columnas.

**Solución**
Se asignó un valor de ancho tanto al heading como al listado de modo que siempre coinciden los elementos independientemente de la existencia de una botonera.