### PR TITLE
Plex text height

### DIFF
--- a/src/demo/app/text/text.html
+++ b/src/demo/app/text/text.html
@@ -78,7 +78,7 @@
             <div class="col-md-6">
                 <form>
                     <plex-text label="Escriba el informe" [(ngModel)]="richText.contenido" name="contenido2"
-                               [html]="true" [height]="500" [readonly]="false">
+                               [html]="true" [height]="'500px'" [readonly]="false">
                     </plex-text>
                 </form>
             </div>

--- a/src/lib/text/text.component.ts
+++ b/src/lib/text/text.component.ts
@@ -101,8 +101,12 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
     }
 
     @Input()
-    set height(value: number) {
-        this.quillStyle.height = value + 'px';
+    set height(value: number | string) {
+        if (typeof value === 'number') {
+            this.quillStyle.height = value + 'px';
+        } else {
+            this.quillStyle.height = value;
+        }
     }
     @Input()
     set autoFocus(value: any) {


### PR DESCRIPTION
Solo se podía setear una altura en __px__. Ahora se puede pasar la unidad en el mismo valor. Depende del tipo del parametro. 