### PR TITLE
fix(tooltip): display flex para evitar pesada herencia de display

### DIFF
--- a/src/lib/css/tooltip.scss
+++ b/src/lib/css/tooltip.scss
@@ -1,13 +1,16 @@
-$tooltip-padding-y: .35rem;
-$tooltip-padding-x: .55rem;
+$tooltip-padding-y: 0.35rem;
+$tooltip-padding-x: 0.55rem;
 $border-radius: 4px;
 // $tooltip-bg: #616161;
-$tooltip-opacity: .7;
+$tooltip-opacity: 0.7;
 $tooltip-arrow-color: #616161;
 
 .tooltip {
+    display: flex;
 
-    &.show { opacity: $tooltip-opacity; }
+    &.show {
+        opacity: $tooltip-opacity;
+    }
 
     // Wrapper for the tooltip content
     .tooltip-inner {


### PR DESCRIPTION
El tooltip tenía algunos problemas al heredar el tipo de display del contenedor padre del elemento que tiene al mismo (al tooltip).
Se aplicó `display: flex;` para forzar que siempre se muestre de esta manera, evitando problemas de alineamiento en distintas anidaciones.