### PR TITLE
fix(plex-wrapper): agrega plex-int como elemento del componente

### DIFF
--- a/src/demo/app/wrapper/wrapper.html
+++ b/src/demo/app/wrapper/wrapper.html
@@ -4,16 +4,20 @@
             <plex-button type="success" size="sm">accion satisfactoria</plex-button>
         </plex-title>
         <plex-wrapper>
-            <plex-datetime label="Ingrese la fecha" [(ngModel)]="tModel.fechaHora" name="fechaHora">
+            <plex-datetime grow="4" label="Ingrese la fecha" [(ngModel)]="tModel.fechaHora" name="fechaHora">
             </plex-datetime>
-            <plex-select grow="auto" [(ngModel)]="modelo1.select" [data]="opciones"
+            <plex-int grow="4" label="plex-int" [(ngModel)]="tModel.valor" name="valor" min="10" max="90" suffix="%">
+            </plex-int>
+            <plex-select grow="4" [(ngModel)]="modelo1.select" [data]="opciones"
                          label="Seleccione efector ojo que tiene nombre largo">
             </plex-select>
-            <plex-text label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre"> </plex-text>
-
+            <plex-text grow="4" label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre">
+            </plex-text>
+            <plex-float grow="1" label="plex-float" placeholder="Ingrese porcentaje entre 10.5 y 90.4"
+                        [(ngModel)]="tModel.valor" name="valor" [min]="10.5" [max]="90.4" suffix="%"></plex-float>
             <div collapse>
-                <plex-float label="plex-float" placeholder="Ingrese porcentaje entre 10.5 y 90.4"
-                            [(ngModel)]="tModel.valor" name="valor" [min]="10.5" [max]="90.4" suffix="%"></plex-float>
+                <plex-int label="plex-int" [(ngModel)]="tModel.valor" name="valor" min="10" max="90" suffix="%">
+                </plex-int>
                 <plex-bool [(ngModel)]="modelo.slide" type="slide" label="¿Está activo?" name="slide"></plex-bool>
                 <plex-text label="Buscar profesional" [(ngModel)]="templateModel2.nombre" name="nombre"></plex-text>
                 <plex-select grow="2" [(ngModel)]="modelo1.select" [data]="opciones"

--- a/src/lib/css/plex-wrapper.scss
+++ b/src/lib/css/plex-wrapper.scss
@@ -46,7 +46,7 @@ plex-wrapper  {
         margin-right: 1rem;
     }
 
-    plex-select, plex-phone, plex-text, plex-float {
+    plex-int, plex-select, plex-phone, plex-text, plex-float {
         @include baseInputs;
         flex: 1 0 190px;
     }
@@ -80,7 +80,6 @@ plex-wrapper  {
     }
 
     // Componentes de ancho variable
-    
     @media screen and (max-width: 768px) {
         // Para que los elementos con directiva 'columns' no restringan la grilla
         plex-datetime, plex-phone, plex-text, plex-float {
@@ -89,27 +88,27 @@ plex-wrapper  {
     }
     
     // Directiva Columns
-    .grid-columns-auto {
+    .grow-auto {
         flex: auto;
     }
 
-    .grid-columns-span-1 {
+    .grow-1 {
         flex-grow: 1;
     }
 
-    .grid-columns-span-2 {
+    .grow-2 {
         flex-grow: 2;
     }
 
-    .grid-columns-span-3 {
+    .grow-3 {
         flex-grow: 3;
     }
 
-    .grid-columns-span-4 {
+    .grow-4 {
         flex-grow: 4;
     }
 
-    .grid-columns-full {
+    .grow-full {
         flex-basis: 100%;
     }
 }

--- a/src/lib/directives/grow.directive.ts
+++ b/src/lib/directives/grow.directive.ts
@@ -7,27 +7,27 @@ import { Directive, Input, HostBinding } from '@angular/core';
 export class GrowDirective {
     @Input() grow: 'auto' | '1' | '2' | '3' | '4' | 'full' = 'auto';
 
-    @HostBinding('class.grid-columns-full') get full() {
+    @HostBinding('class.grow-full') get full() {
         return this.grow === 'full';
     }
 
-    @HostBinding('class.grid-columns-auto') get auto() {
+    @HostBinding('class.grow-auto') get auto() {
         return this.grow === 'auto';
     }
 
-    @HostBinding('class.grid-columns-span-1') get grow1() {
+    @HostBinding('class.grow-1') get grow1() {
         return this.grow === '1';
     }
 
-    @HostBinding('class.grid-columns-span-2') get grow2() {
+    @HostBinding('class.grow-2') get grow2() {
         return this.grow === '2';
     }
 
-    @HostBinding('class.grid-columns-span-3') get grow3() {
+    @HostBinding('class.grow-3') get grow3() {
         return this.grow === '3';
     }
 
-    @HostBinding('class.grid-columns-span-4') get grow4() {
+    @HostBinding('class.grow-4') get grow4() {
         return this.grow === '4';
     }
 }


### PR DESCRIPTION
**Problema:**
El input plex-int no formaba parte de la hoja de estilos del plex-wrapper, causando que no adquiera propiedades heredadas del mismo (margins, alineamiento, etc.).

**Solución:**
Se agrega plex-int en la hoja de estilos del plex-wrapper

**Plus:** se cambia nombre de clase de la directiva 'grow' de '.grid-columns-span-n' a '.grow-n' 