### PR TITLE
fix(plex-item): corrige ancho de inputs y desacopla directiva span del grid

### DIFF
--- a/src/demo/app/item-list/item-list.component.ts
+++ b/src/demo/app/item-list/item-list.component.ts
@@ -48,7 +48,13 @@ export class ItemDemoComponent implements OnInit {
     ];
 
     public dropitems: DropdownItem[];
-
+    public opciones: any[];
+    public modelo1 = { select: null, radio: null };
+    public modelo2 = {
+        select: null,
+        soloLectura: false,
+        selectMultiple: null
+    };
     public model1: any;
     public model2: any;
     public tModel: any;
@@ -59,6 +65,31 @@ export class ItemDemoComponent implements OnInit {
         this.tModel = { valor: null };
         this.model1 = { valor: null };
         this.model2 = { valor: null };
+        this.modelo1.select = this.modelo2.select = this.opciones;
+
+        // plex-select
+        this.opciones = [{
+            id: 1,
+            nombre: 'Hermano/a',
+        },
+        {
+            id: 2,
+            nombre: 'Padre',
+        },
+        {
+            id: 3,
+            nombre: 'Madre',
+        },
+        {
+            id: 4,
+            nombre: 'Abuelo/a',
+        },
+        {
+            id: 5,
+            nombre: 'Primo/a',
+        }
+        ];
+
 
         this.tModelFecha = {
             fechaHora: null,

--- a/src/demo/app/item-list/item-list.html
+++ b/src/demo/app/item-list/item-list.html
@@ -3,6 +3,7 @@
         <plex-list height="60%" (scrolled)="onScroll()">
             <plex-heading>
                 <b label>Datos importantes</b>
+                <b label>Parentesco</b>
                 <b label>Horario</b>
             </plex-heading>
             <plex-item *ngFor="let item of lista; let par = even" [selected]="item.selected"
@@ -160,6 +161,8 @@
                 <plex-label [titulo]="item.name" [tituloBold]="par"
                             subtitulo="10:00 a 11:00 hs 1 hora 10:00 a 11:00 hs 1 hora 10:00 a 11:00 hs 1 hora 10:00 a 11:00 hs 1 hora">
                 </plex-label>
+                <plex-select [(ngModel)]="modelo1.select" [data]="opciones" label="">
+                </plex-select>
                 <plex-dropdown icon="dots-vertical mdi-24px" [right]="true" [items]="dropitems">
                 </plex-dropdown>
                 <plex-button type="warning" size="sm" icon="clock"></plex-button>

--- a/src/lib/css/plex-grid.scss
+++ b/src/lib/css/plex-grid.scss
@@ -61,21 +61,21 @@ plex-grid {
         --colSize: 14rem;
         --rowSize: 14rem;
     }	
-
-    // directiva span
-    .grid-column-auto {
-        grid-column: auto;
-    }
-    .grid-column-span-2 {
-        grid-column: span 2;
-    }
-    .grid-column-span-3 {
-        grid-column: span 3;
-    }
-    .grid-column-span-4 {
-        grid-column: span 4;
-    }
-    .grid-column-span-full {
-        grid-column: 100%;
-    }	
 } 
+
+// directiva span
+.grid-column-auto {
+    grid-column: auto;
+}
+.grid-column-span-2 {
+    grid-column: span 2;
+}
+.grid-column-span-3 {
+    grid-column: span 3;
+}
+.grid-column-span-4 {
+    grid-column: span 4;
+}
+.grid-column-span-full {
+    grid-column: 100%;
+}	

--- a/src/lib/css/plex-item.scss
+++ b/src/lib/css/plex-item.scss
@@ -141,7 +141,6 @@ plex-list {
                 >* {
                     display: flex;
                     align-items: center;
-                    justify-self: flex-start;
                 }
             
                 // Items que componen la lista que no son componentes Angular
@@ -163,6 +162,13 @@ plex-list {
                     flex-flow: column-reverse;
                 }
             
+                plex-select, plex-select, plex-phone, plex-text, plex-float, plex-int {
+                    div.form-group {
+                        min-width: 135px;
+                        width: 100%;
+                    }
+                }
+
                 plex-datetime {
                     justify-self: flex-start !important;
                     width: 135px; 


### PR DESCRIPTION
**Problema:**
Los anchos de los inputs presentes en el plex-item no respondían a la grilla interna.

**Solución**
Se los incorpora a la hoja de estilo del componente y se les setea un width y un min-width (que se corresponde con el valor mínimo que adquiere la celda de la grilla).

**Captura del problema**
![plex-item-select-issue](https://user-images.githubusercontent.com/5895886/85851654-7b933600-b785-11ea-84f6-59344c079b6f.PNG)

**Captura de la solución**
![plex-item-select](https://user-images.githubusercontent.com/5895886/85851812-c4e38580-b785-11ea-9a2b-6453d4c674dd.PNG)

