### PR TITLE
feat(layout-responsive): permite secuenciar el layout en responsive 

### DIFF
--- a/src/demo/app/templates/listado-sidebar/listado-sidebar.html
+++ b/src/demo/app/templates/listado-sidebar/listado-sidebar.html
@@ -1,4 +1,4 @@
-<plex-layout main="8">
+<plex-layout [main]="foco === 'main' ? 12 : 8 " [foco]="foco">
     <plex-layout-main>
         <plex-title size="lg" titulo="Bienvenido a Plex">
             <plex-help type="help" titulo="Ayuda de este panel" size="sm" title="este es un atributo [title]"
@@ -41,7 +41,8 @@
     <plex-layout-sidebar type="invert">
         <plex-tabs size="full">
             <plex-tab label="tab-1" icon="star" active="true">
-                <router-outlet></router-outlet>
+                <router-outlet (activate)="foco = 'sidebar'" (deactivate)="foco = 'main'">
+                </router-outlet>
             </plex-tab>
 
             <plex-tab label="tab-2" icon="star" active="true">

--- a/src/demo/app/templates/listado-sidebar/listado-sidebar.html
+++ b/src/demo/app/templates/listado-sidebar/listado-sidebar.html
@@ -1,4 +1,4 @@
-<plex-layout [main]="foco === 'main' ? 12 : 8 " [foco]="foco">
+<plex-layout [aspect]="8">
     <plex-layout-main>
         <plex-title size="lg" titulo="Bienvenido a Plex">
             <plex-help type="help" titulo="Ayuda de este panel" size="sm" title="este es un atributo [title]"
@@ -41,8 +41,7 @@
     <plex-layout-sidebar type="invert">
         <plex-tabs size="full">
             <plex-tab label="tab-1" icon="star" active="true">
-                <router-outlet (activate)="foco = 'sidebar'" (deactivate)="foco = 'main'">
-                </router-outlet>
+                <router-outlet></router-outlet>
             </plex-tab>
 
             <plex-tab label="tab-2" icon="star" active="true">

--- a/src/demo/app/templates/listado-sidebar/listado-sidebar.ts
+++ b/src/demo/app/templates/listado-sidebar/listado-sidebar.ts
@@ -32,7 +32,7 @@ export class ListadoSidebarComponent implements OnInit {
 
     // public listadoPaciente: Paciente[];
     pacientes$: Observable<Paciente[]>;
-    selectedId: Number;
+    foco = 'main';
     public prueba = '';
     public cambio = '';
     constructor(
@@ -41,15 +41,8 @@ export class ListadoSidebarComponent implements OnInit {
         private plex: Plex
     ) { }
 
+
     ngOnInit() {
-        this.pacientes$ = this.route.paramMap.pipe(
-            switchMap(params => {
-                this.selectedId = +params.get('id');
-                return this.pacienteService.getPacientes();
-            })
-        );
-
-
         // plex-datetime
         this.tModel = {
             fechaHora: null,

--- a/src/lib/css/layout.scss
+++ b/src/lib/css/layout.scss
@@ -50,7 +50,7 @@ plex-layout {
     background: white!important;
   } 
 
-  section.size-sm {
+  section.size-xs {
       .focused {
           flex: 0 0 100%;
           max-width: 100%;

--- a/src/lib/css/layout.scss
+++ b/src/lib/css/layout.scss
@@ -50,6 +50,24 @@ plex-layout {
     background: white!important;
   } 
  
+
+  // > plex-layout-sidebar {
+  //   > .row:first-child {
+  //     padding: 0px 15px 0px 10px;
+  //   }
+  // }
+
+  section.size-xs {
+      .focused {
+          flex: 0 0 100%;
+          max-width: 100%;
+      }
+
+      .not-focused {
+          display: none;
+      }
+  }
+
   // Footer (se ubica fijo abajo de la pantalla)
    > plex-layout-footer,
   > footer {

--- a/src/lib/css/layout.scss
+++ b/src/lib/css/layout.scss
@@ -49,15 +49,8 @@ plex-layout {
   .mat-checkbox-inner-container {
     background: white!important;
   } 
- 
 
-  // > plex-layout-sidebar {
-  //   > .row:first-child {
-  //     padding: 0px 15px 0px 10px;
-  //   }
-  // }
-
-  section.size-xs {
+  section.size-sm {
       .focused {
           flex: 0 0 100%;
           max-width: 100%;
@@ -66,6 +59,11 @@ plex-layout {
       .not-focused {
           display: none;
       }
+
+    //  Calle izq. del sidebar en responsive
+      > div > div:nth-child(2) {
+        padding-left: 10px;
+      } 
   }
 
   // Footer (se ubica fijo abajo de la pantalla)

--- a/src/lib/layout/layout.component.ts
+++ b/src/lib/layout/layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ContentChild, AfterViewInit, AfterContentInit, AfterContentChecked, ComponentRef, ElementRef } from '@angular/core';
+import { Component, Input, ContentChild, AfterViewInit, AfterContentInit, AfterContentChecked, ComponentRef, ElementRef, DebugElement } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { EventEmitter } from 'events';
 
@@ -33,12 +33,44 @@ import { EventEmitter } from 'events';
     <ng-content select="plex-layout-footer"></ng-content>
   `,
 })
-export class PlexLayoutComponent {
+export class PlexLayoutComponent implements AfterContentInit {
     // Compatibility mode
     public maxcolumns = 12;
     @Input() main = 12;
 
+    @ContentChild(RouterOutlet, { static: true }) routerOutlet: RouterOutlet;
+
+    @Input() aspect = 12;
+
     @Input() foco: 'main' | 'sidebar' = null;
+
+    ngOnit() {
+        if (this.aspect) {
+            this.foco = 'main';
+            this.main = 12;
+        }
+    }
+
+    ngAfterContentInit() {
+        // MODO MANUAL
+        if (!this.aspect) { return; }
+
+        if (this.routerOutlet.isActivated) {
+            this.main = this.aspect;
+            this.foco = 'sidebar';
+        } else {
+            this.foco = 'main';
+        }
+        this.routerOutlet.activateEvents.subscribe(() => {
+            this.main = this.aspect;
+            this.foco = 'sidebar';
+        });
+
+        this.routerOutlet.deactivateEvents.subscribe(() => {
+            this.main = 12;
+            this.foco = 'main';
+        });
+    }
 
 
     constructor() {

--- a/src/lib/layout/layout.component.ts
+++ b/src/lib/layout/layout.component.ts
@@ -1,14 +1,31 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ContentChild, AfterViewInit, AfterContentInit, AfterContentChecked, ComponentRef, ElementRef } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { EventEmitter } from 'events';
+
+/**
+ * ATENCION! SI NO SE ESTABLECE FOCO SE MANTIENE FUNCIONALIDAD ANTERIOR.
+ *
+ * TIENEN UN NGIF SI MAIN = 12
+ * HACIENDO QUE EL CONTENIDO DEL SIDEBAR NO SE RENDERIZE.
+ * SI SIMPLEMENTE LO OCULTO, PUEDE CAUSAR ERRORES QUE NO SABEMOS
+ * NO TODOS LOS SIDEBAR DEBEN ESTAR PREPARADOS
+ */
 
 @Component({
     selector: 'plex-layout',
     template: `
-    <section>
+    <section responsive>
         <div class="row">
-            <div class="col-{{ main }} h-100">
+            <div class="col-{{ main }} h-100"
+                 [class.focused]="foco === 'main'"
+                 [class.not-focused]="foco !== 'main'">
                 <ng-content select="plex-layout-main"></ng-content>
             </div>
-            <div class="col-{{ maxcolumns - main }} h-100" *ngIf="main < maxcolumns">
+            <div class="col-{{ maxcolumns - main }} h-100"
+                 *ngIf="(main < maxcolumns && !foco) || !!foco"
+                 [hidden]="main === maxcolumns && foco"
+                 [class.focused]="foco === 'sidebar'"
+                 [class.not-focused]="foco !== 'sidebar'">
                 <ng-content select="plex-layout-sidebar"></ng-content>
             </div>
         </div>
@@ -17,9 +34,15 @@ import { Component, Input } from '@angular/core';
   `,
 })
 export class PlexLayoutComponent {
+    // Compatibility mode
     public maxcolumns = 12;
     @Input() main = 12;
 
+    @Input() foco: 'main' | 'sidebar' = null;
+
+
     constructor() {
     }
+
+
 }

--- a/src/lib/layout/layout.component.ts
+++ b/src/lib/layout/layout.component.ts
@@ -54,22 +54,23 @@ export class PlexLayoutComponent implements AfterContentInit {
     ngAfterContentInit() {
         // MODO MANUAL
         if (!this.aspect) { return; }
+        if (this.routerOutlet) {
+            if (this.routerOutlet.isActivated) {
+                this.main = this.aspect;
+                this.foco = 'sidebar';
+            } else {
+                this.foco = 'main';
+            }
+            this.routerOutlet.activateEvents.subscribe(() => {
+                this.main = this.aspect;
+                this.foco = 'sidebar';
+            });
 
-        if (this.routerOutlet.isActivated) {
-            this.main = this.aspect;
-            this.foco = 'sidebar';
-        } else {
-            this.foco = 'main';
+            this.routerOutlet.deactivateEvents.subscribe(() => {
+                this.main = 12;
+                this.foco = 'main';
+            });
         }
-        this.routerOutlet.activateEvents.subscribe(() => {
-            this.main = this.aspect;
-            this.foco = 'sidebar';
-        });
-
-        this.routerOutlet.deactivateEvents.subscribe(() => {
-            this.main = 12;
-            this.foco = 'main';
-        });
     }
 
 


### PR DESCRIPTION
**1. Cómo funciona?**
Mediante la inyección de dos propiedades CSS:
a. focused (flexea el panel acaparando el 100% del ancho)
b. not-focused (fuerza un display: none)

![plex-layout-responsive](https://user-images.githubusercontent.com/5895886/86363533-5ef77200-bc4d-11ea-916d-0c32aa4d8bcd.gif)
