### PR TITLE
fix(plex-select): valor inicial multiple

### DIFF
--- a/src/lib/select/select.component.ts
+++ b/src/lib/select/select.component.ts
@@ -356,7 +356,7 @@ export class PlexSelectComponent implements AfterViewInit, ControlValueAccessor 
 
             // Setea el valor
             if (value) {
-                const temp = { ...value };
+                const temp = Array.isArray(value) ? [...value] : { ...value };
                 this.selectize.addOption(temp);
                 this.selectize.setValue(val, true);
             } else {


### PR DESCRIPTION
No se podía setear como valor inicial un array de opciones, en el caso de select multiples