### PR TITLE
Directiva plTab

### DIFF
--- a/src/demo/app/tabs/tabs.component.ts
+++ b/src/demo/app/tabs/tabs.component.ts
@@ -1,5 +1,7 @@
 import { Plex } from './../../../lib/core/service';
 import { Component, OnDestroy } from '@angular/core';
+import { from, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 @Component({
     templateUrl: 'tabs.html',
@@ -13,6 +15,11 @@ export class TabsDemoComponent {
         { label: 'amplifier', icon: 'amplifier', color: 'trastorno' },
         { label: 'amazon', icon: 'amazon', color: 'default' }
     ];
+
+    public contenidoAsync = of([1, 2, 3]).pipe(
+        // tslint:disable-next-line:no-console
+        tap(console.log)
+    );
 
     constructor(private plex: Plex) {
     }

--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -16,8 +16,9 @@
 				</div>
 			</plex-tab>
 			<plex-tab icon="history">
-				<div class="alert alert-danger">
+				<div class="alert alert-danger" *plTab="5000">
 					Contenido 3
+					<span *ngFor="let item of contenidoAsync | async"> {{ item }} </span>
 				</div>
 			</plex-tab>
 		</plex-tabs>

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -72,6 +72,7 @@ import { NavItemComponent } from './app/nav-item.component';
 import { HintComponent } from './hint/hint.component';
 import { HintDirective } from './hint/hint.directive';
 import { HelpDirective } from './help/help.directive';
+import { TabDirective } from './tabs/pl-tab.directive';
 
 const MODULES = [
     PlexAppComponent,
@@ -123,7 +124,8 @@ const MODULES = [
     PlexWrapperComponent,
     PlexGridComponent,
     HintDirective,
-    HelpDirective
+    HelpDirective,
+    TabDirective
     // MatTooltip
 ];
 

--- a/src/lib/tabs/pl-tab.directive.ts
+++ b/src/lib/tabs/pl-tab.directive.ts
@@ -1,0 +1,51 @@
+import { Directive, TemplateRef, ViewContainerRef, OnDestroy, OnInit, ChangeDetectorRef, Input } from '@angular/core';
+import { Subscription, merge, interval, NEVER } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { PlexTabComponent } from './tab.component';
+
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[plTab]'
+})
+export class TabDirective<T> implements OnDestroy, OnInit {
+    private openSubscription: Subscription;
+    private viewRef: any = null;
+
+    /**
+     * Renderizar el contenido de una tab de forma asyncrona. Si se indica milisegundos se pospone la carga aunque no se active la tab.
+     **/
+    @Input() plTab: number;
+
+    constructor(
+        private view: ViewContainerRef,
+        private nextRef: TemplateRef<ObserveContext<T>>,
+        private changes: ChangeDetectorRef,
+        private plexTab: PlexTabComponent
+    ) { }
+
+
+    ngOnDestroy() {
+        this.openSubscription.unsubscribe();
+    }
+
+    ngOnInit() {
+        const timer = this.plTab ? interval(this.plTab) : NEVER;
+        this.openSubscription = merge(
+            this.plexTab.toggle.pipe(filter(active => active)),
+            timer
+        ).subscribe(() => {
+            if (!this.viewRef) {
+                this.viewRef = this.view.createEmbeddedView(this.nextRef);
+                this.changes.markForCheck();
+                this.openSubscription.unsubscribe();
+            }
+        });
+    }
+
+}
+
+interface ObserveContext<T> {
+    $implicit: T;
+    observe: T;
+}

--- a/src/lib/tabs/tab.component.ts
+++ b/src/lib/tabs/tab.component.ts
@@ -1,13 +1,21 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
     selector: 'plex-tab',
     template: `<ng-content *ngIf='active'></ng-content>`,
 })
 export class PlexTabComponent {
+
     @Input() label: string;
+
     @Input() icon: string;
+
     @Input() active: boolean;
+
     @Input() allowClose: boolean;
+
     @Input() color = 'default';
+
+    @Output() toggle = new EventEmitter<boolean>();
+
 }

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -59,11 +59,15 @@ export class PlexTabsComponent implements AfterContentInit {
     selectTab(tab: PlexTabComponent) {
         setTimeout(() => {
             this.tabs.forEach((t) => {
+                if (t.active) {
+                    t.toggle.emit(false);
+                }
                 t.active = false;
             });
             tab.active = true;
             this._activeIndex = this.tabs.indexOf(tab);
             this.change.emit(this._activeIndex);
+            tab.toggle.emit(true);
 
             // Focus tab header
             const tabHeader = this.container.nativeElement.children[this._activeIndex];


### PR DESCRIPTION
Permite carga de forma asyncrona el contenido de una tab. Dos alternativas:

1. Cuando el usuario hace click en la tab, el contenido recién ahí se renderiza.
2. Indicar un tiempo de gracias, pasado ese tiempo se renderiza el contenido (no quiere decir que se muestre).

**Motivaciones**:
Hay tabs de pocos usos que hacen llamados al servidor. La idea es evitar esos llamados o que no se encolen con los request principales de la pantalla. 