### PR TITLE
feat(plex-badge): se agrega valor block a la propiedad size

### DIFF
--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -45,16 +45,17 @@
         </form>
     </plex-layout-main>
     <plex-layout-sidebar>
-        <plex-title titulo="PLEX-BADGE"></plex-title>
-        <hr>
-
+        <plex-title titulo="plex-badge: types"></plex-title>
         <plex-title size="sm" titulo="badge normal"></plex-title>
         <plex-badge size="sm" type="success" class="mr-1">VALIDADO</plex-badge>
         <plex-badge size="sm" type="warning" class="mr-1">TEMPORAL</plex-badge>
         <plex-badge size="sm" type="danger" class="mr-1">RESTRINGIDO</plex-badge>
         <plex-badge size="sm" type="info" class="mr-1">14/02/2020</plex-badge>
         <plex-badge size="sm" type="default" class="mr-1">EN PLANIFICACIÓN</plex-badge>
-
+        <hr>
+        <plex-title titulo="type=block" size="sm"></plex-title>
+        <plex-badge size="block" type="success" class="mr-1">Este badge acapara todo el espacio disponible
+        </plex-badge>
         <hr>
         <plex-title size="sm" titulo="button y badge"></plex-title>
         <plex-badge size="sm" type="warning" class="mr-1">TEMPORAL

--- a/src/lib/badge/badge.component.ts
+++ b/src/lib/badge/badge.component.ts
@@ -15,7 +15,7 @@ import { Component, Input, ElementRef, ViewChild, OnChanges } from '@angular/cor
 })
 export class PlexBadgeComponent implements OnChanges {
     @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'default';
-    @Input() size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'md';
+    @Input() size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'block' = 'md';
     @Input() color: string;
 
     @ViewChild('badge', { static: true }) el: ElementRef;

--- a/src/lib/css/plex-badge.scss
+++ b/src/lib/css/plex-badge.scss
@@ -25,6 +25,16 @@
 plex-badge {
     display: inline-flex;
     align-items: flex-end;
+
+    &[size="block"] {
+        width: 100%;
+        
+        span.badge-block {
+            display: block;
+            width: 100%;
+        }
+    }
+
     plex-datetime {
         display: inline-flex;
     }


### PR DESCRIPTION
Se agrega valor 'block' para que el badge se comporte en concordancia con el plex-button y lograr casos como el siguiente:

![badge-block](https://user-images.githubusercontent.com/5895886/87781122-76fef200-c806-11ea-929d-fae9982aa8cc.jpg)
