### PR TITLE
feat(hint): permite hint clickeable

### DIFF
--- a/src/demo/app/tooltip-hint/tooltip-hint.component.ts
+++ b/src/demo/app/tooltip-hint/tooltip-hint.component.ts
@@ -7,4 +7,8 @@ export class TooltipHintDemoComponent implements OnInit {
     constructor() { }
 
     ngOnInit(): void { }
+
+    alertar(e) {
+        alert(`Inner HTML: ${e.target.innerHTML}`);
+    }
 }

--- a/src/demo/app/tooltip-hint/tooltip-hint.html
+++ b/src/demo/app/tooltip-hint/tooltip-hint.html
@@ -6,7 +6,7 @@
             </plex-button>
             <plex-button class="ml-1" size="sm" type="danger"
                          hint="¿Sabías que... el hint es un texto que sugiere acciones o indica alguna novedad? Además tiene soporte multilínea."
-                         position="above">
+                         position="above" (click)="alertar($event);">
                 hint
             </plex-button>
         </plex-title>

--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -1,10 +1,9 @@
-import { MatTooltip } from '@angular/material/tooltip';
-import { Component, OnInit, AfterViewInit, Host, Self, Optional, Input, ElementRef, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, AfterViewInit, Input, ChangeDetectorRef, HostListener } from '@angular/core';
 
 @Component({
     selector: 'plex-hint',
     template: `
-        <a (click)="$event.preventImmediatePropagation()" href="javascript:void(0)" *ngIf="position" class="hint-container" [matTooltip]="content" [matTooltipPosition]="position">
+        <a href="javascript:void(0)" *ngIf="position" class="hint-container" [matTooltip]="content" [matTooltipPosition]="position">
             <plex-icon class="hint" [name]="icon" type="default"></plex-icon>
         </a>
     `
@@ -30,6 +29,11 @@ export class HintComponent implements OnInit, AfterViewInit {
 
     ngAfterViewInit(): void {
         this.cdr.detectChanges();
+    }
+
+    // Si el elemento que tiene la directiva [hint] tiene un evento (click), este se ejecutará, guste o no.
+    @HostListener('click', ['$event']) onClick() {
+        this.hostElement.click();
     }
 
 }


### PR DESCRIPTION
El hint usa funcionalidad (click) del elemento padre:

- `<span hint="actualizar" (click)="actualizar()>Hola Mundo Plano!</span>`

El ejemplo anterior mostrará un texto con un hint, el cual ejecutará actualizar() al ser clickeado.