### PR TITLE
plex-help, revisión visual y funcional

### DIFF
--- a/cypress/integration/detail.js
+++ b/cypress/integration/detail.js
@@ -14,7 +14,7 @@ context('detail', () => {
 
         // cy.eyesCheckWindow('plex-detail - scrool');
 
-        cy.get('plex-layout plex-help').plexButtonIcon('informacion').click();
+        cy.get('plex-layout plex-help').plexButtonIcon('help').click();
 
         cy.eyesCheckWindow('plex-detail - plex-help');
 

--- a/cypress/integration/help.js
+++ b/cypress/integration/help.js
@@ -11,7 +11,7 @@ context('help', () => {
 
     it('Abre y cierra help', () => {
 
-        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('informacion');
+        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('help');
         helpOpen.click();
         cy.get('.card-body:first').should('contain.text', 'Organización');
 
@@ -24,7 +24,7 @@ context('help', () => {
 
     it('Falla porque el botón está oculto por otro panel de plex-help', (done) => {
 
-        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('informacion');
+        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('help');
         helpOpen.click();
 
         const helpOpenFail = cy.get('plex-layout plex-help').eq(1).plexButtonIcon('help');

--- a/cypress/integration/help.js
+++ b/cypress/integration/help.js
@@ -6,15 +6,35 @@ context('help', () => {
         cy.visit('/help');
     });
 
-    it('abre y cierra help', () => {
+    it('Abre y cierra help', () => {
 
-        cy.get('plex-layout plex-help:first').plexButtonIcon('help-circle').click();
+        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('information-variant');
+        helpOpen.click();
+        cy.get('.card-body:first').should('contain.text', 'Organización');
 
-        cy.get('plex-layout plex-help').plexButtonIcon('informacion').click();
+        const helpClose = cy.get('plex-layout plex-help:first').plexButtonIcon('close');
+        helpClose.click();
 
         cy.eyesCheckWindow('plex-help');
 
         cy.eyesClose();
 
+    });
+
+    it('Falla porque el botón está oculto por otro panel de plex-help', (done) => {
+
+        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('information-variant');
+        helpOpen.click();
+
+        const helpOpenFail = cy.get('plex-layout plex-help').eq(1).plexButtonIcon('help');
+        helpOpenFail.click();
+
+        cy.once('fail', (err) => {
+
+            expect(err.message).to.include('`cy.click()` failed because this element');
+            expect(err.message).to.include('is being covered by another element');
+
+            done();
+        });
     });
 });

--- a/cypress/integration/help.js
+++ b/cypress/integration/help.js
@@ -2,20 +2,21 @@
 
 context('help', () => {
     before(() => {
-        cy.eyesOpen({ appName: 'PLEX', testName: 'plex-help' });
+        cy.eyesOpen({
+            appName: 'PLEX',
+            testName: 'plex-help'
+        });
         cy.visit('/help');
     });
 
     it('Abre y cierra help', () => {
 
-        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('information-variant');
+        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('informacion');
         helpOpen.click();
         cy.get('.card-body:first').should('contain.text', 'Organización');
 
         const helpClose = cy.get('plex-layout plex-help:first').plexButtonIcon('close');
         helpClose.click();
-
-        cy.eyesCheckWindow('plex-help');
 
         cy.eyesClose();
 
@@ -23,7 +24,7 @@ context('help', () => {
 
     it('Falla porque el botón está oculto por otro panel de plex-help', (done) => {
 
-        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('information-variant');
+        const helpOpen = cy.get('plex-layout plex-help:first').plexButtonIcon('informacion');
         helpOpen.click();
 
         const helpOpenFail = cy.get('plex-layout plex-help').eq(1).plexButtonIcon('help');

--- a/cypress/integration/template-listado.js
+++ b/cypress/integration/template-listado.js
@@ -36,7 +36,7 @@ context('template listado', () => {
 
         cy.eyesCheckWindow('accordion open');
 
-        cy.get('plex-help').plexButtonIcon('help-circle').click();
+        cy.get('plex-help').plexButtonIcon('help').click();
 
         cy.eyesCheckWindow('plex-help open');
 

--- a/src/demo/app/help/help.html
+++ b/src/demo/app/help/help.html
@@ -3,7 +3,7 @@
 
         <plex-title titulo="plex-help (type ='help')">
             <plex-button size="sm" type="warning" label="acción sensible"></plex-button>
-            <plex-help type="info" titulo="Ayuda de este panel" size="sm" class="ml-1">
+            <plex-help type="info" titulo="Ayuda de este panel" size="sm">
                 <div class="ml-4 mb-4" *plHelp>
                     <label>Organización:</label>
                     prestacion.solicitud.organizacion.nombre
@@ -31,7 +31,7 @@
                 </li>
             </ul>
             <hr>
-            <plex-title size="sm" titulo="plex-help (size:'sm')" class="mb-4">
+            <plex-title size="sm" titulo="plex-help" class="mb-4">
                 <plex-help titulo="size = sm" size="sm">
                     <div class="ml-4 mb-4">
                         <label>Organización:</label>
@@ -39,16 +39,16 @@
                     </div>
                 </plex-help>
             </plex-title>
-            <p>plex-help (size:'md')</p>
-            <plex-title size="md" titulo="plex-help (size:'md' y cardSize:'half')" class="mb-4">
-                <plex-help titulo="size = md, cardSize = half" size="md" cardSize="half">
+            <p>plex-help (size:'sm')</p>
+            <plex-title size="sm" titulo="plex-help (cardSize:'half')" class="mb-4">
+                <plex-help titulo="size = sm, cardSize = half" size="sm" cardSize="half">
                     <div class="ml-4 mb-4">
                         <label>Organización:</label>
                         prestacion.solicitud.organizacion.nombre
                     </div>
                 </plex-help>
             </plex-title>
-            <p>plex-help (size:'md' y cardSize:'half')</p>
+            <p>plex-help (cardSize:'half')</p>
 
         </main>
 
@@ -58,7 +58,7 @@
 
         <plex-title titulo="plex-help (type ='info')" size="sm">
             <plex-button size="sm" type="success" label="acción satisfactoria"></plex-button>
-            <plex-help class="ml-1" titulo="Información sobre este panel" subtitulo="A continuación los pasos a seguir">
+            <plex-help titulo="Información sobre este panel" subtitulo="A continuación los pasos a seguir">
                 <ol info class="list-group-flush">
                     <li>Buscá conceptos SNOMED en el campo de texto del panel lateral
                         (acepta búsquedas
@@ -68,14 +68,9 @@
                     <li>Completá los campos "Título" y "Texto del procedimiento"</li>
                     <li>Opcionalmente podés elegir seleccionar a todos los descendientes
                         del concepto.</li>
-                    <<<<<<< HEAD <li class="list-group-item">Hacé click en "Guardar todos" o el botón con el signo
-                        <plex-icon type="default" size="md" name="check"></plex-icon> para guardar una plantilla
-                        individual</li>
-                        =======
-                        <li>Hacé click en "Guardar todos" o el botón con el signo <i class="mdi mdi-check"></i> para
-                            guardar
-                            una plantilla individual</li>
-                        >>>>>>> c3ad997... feat(demo plex-help): se actualiza con nuevas opciones
+                    <li>Hacé click en "Guardar todos" o el botón con el signo <i class="mdi mdi-check"></i> para
+                        guardar
+                        una plantilla individual</li>
                 </ol>
             </plex-help>
         </plex-title>
@@ -94,31 +89,14 @@
         </h6>
         <plex-title titulo="plex-help con botones" size="sm">
             <plex-button size="sm" type="danger" label="acción peligrosa"></plex-button>
-            <<<<<<< HEAD <plex-help type="help" class="ml-1" titulo="Información sobre este módulo"
-                    subtitulo="A continuación todas las opciones">
-                <ol info class="list-group-flush">
-                    <li class="list-group-item">Buscá conceptos SNOMED en el campo de texto del panel lateral
-                        (acepta búsquedas
-                        parciales)</li>
-                    <li class="list-group-item">Seleccioná el concepto al cual quieras agregar o modificar
-                        plantillas</li>
-                    <li class="list-group-item">Completá los campos "Título" y "Texto del procedimiento"</li>
-                    <li class="list-group-item">Opcionalmente podés elegir seleccionar a todos los descendientes
-                        del concepto.</li>
-                    <li class="list-group-item">Hacé click en "Guardar todos" o el botón con el signo <plex-icon
-                                   type="default" size="md" name="check"></plex-icon> para guardar una plantilla
-                        individual</li>
-                </ol>
-                =======
-                <plex-help class="ml-1" titulo="Ayuda de este panel (invert automático)"
-                           subtitulo="En este contexto se espera un contenido mas bien breve:">
-                    <p>
-                        &mdash;¿Hola? deme el contenido más breve que tenga.<br>
-                        &mdash; ...<br>
-                        &mdash; ¡No, no tan breve!
-                    </p>
-                    >>>>>>> c3ad997... feat(demo plex-help): se actualiza con nuevas opciones
-                </plex-help>
+            <plex-help titulo="Ayuda de este panel (invert automático)"
+                       subtitulo="En este contexto se espera un contenido mas bien breve:">
+                <p>
+                    &mdash;¿Hola? deme el contenido más breve que tenga.<br>
+                    &mdash; ...<br>
+                    &mdash; ¡No, no tan breve!
+                </p>
+            </plex-help>
         </plex-title>
 
     </plex-layout-sidebar>

--- a/src/demo/app/help/help.html
+++ b/src/demo/app/help/help.html
@@ -3,7 +3,7 @@
 
         <plex-title titulo="plex-help (type ='help')">
             <plex-button size="sm" type="warning" label="acción sensible"></plex-button>
-            <plex-help type="help" titulo="Ayuda de este panel" size="sm" class="ml-1">
+            <plex-help type="info" titulo="Ayuda de este panel" size="sm" class="ml-1">
                 <div class="ml-4 mb-4" *plHelp>
                     <label>Organización:</label>
                     prestacion.solicitud.organizacion.nombre
@@ -15,28 +15,42 @@
                 </div>
             </plex-help>
         </plex-title>
-        <p class="lead">El componente <em>plex-help, </em> en su tipología 'help' se emplea en aquellas situaciones en
-            las que consideramos necesario expandir
-            información para guiar al usuario sobre una acción u elemento que
-            cuya finalidad no se intuye por si misma.</p>
-        <plex-title size="sm" titulo="plex-help (size:'sm')" class="mb-4">
-            <plex-help type="help" titulo="size = sm" size="sm">
-                <div class="ml-4 mb-4">
-                    <label>Organización:</label>
-                    prestacion.solicitud.organizacion.nombre
-                </div>
-            </plex-help>
-        </plex-title>
-        <p>plex-help (size:'sm')</p>
-        <plex-title size="md" titulo="plex-help (size:'md')" class="mb-4">
-            <plex-help type="help" titulo="size = md" size="md">
-                <div class="ml-4 mb-4">
-                    <label>Organización:</label>
-                    prestacion.solicitud.organizacion.nombre
-                </div>
-            </plex-help>
-        </plex-title>
-        <p>plex-help (size:'md')</p>
+        <main role="main" class="inner">
+            <p class="lead">
+                El componente <em>plex-help</em> sirve como una ayuda más o menos amplia sobre un
+                módulo, pantalla o sección.
+            </p>
+            <ul>
+                <li class="list-item">En su tipología 'help', muestra un ícono de ayuda, sin subtítulo. Se usa como
+                    ayuda contextual
+                    de un panel o sección dentro de la pantalla.
+                </li>
+                <li class="list-item">En su tipología 'info', muestra un ícono de información, y opcionalmente puede
+                    mostrar un subtítulo. Se usa como un panel de información general, descriptiva de un módulo o
+                    pantalla.
+                </li>
+            </ul>
+            <hr>
+            <plex-title size="sm" titulo="plex-help (size:'sm')" class="mb-4">
+                <plex-help titulo="size = sm" size="sm">
+                    <div class="ml-4 mb-4">
+                        <label>Organización:</label>
+                        prestacion.solicitud.organizacion.nombre
+                    </div>
+                </plex-help>
+            </plex-title>
+            <p>plex-help (size:'md')</p>
+            <plex-title size="md" titulo="plex-help (size:'md' y cardSize:'half')" class="mb-4">
+                <plex-help titulo="size = md, cardSize = half" size="md" cardSize="half">
+                    <div class="ml-4 mb-4">
+                        <label>Organización:</label>
+                        prestacion.solicitud.organizacion.nombre
+                    </div>
+                </plex-help>
+            </plex-title>
+            <p>plex-help (size:'md' y cardSize:'half')</p>
+
+        </main>
 
 
     </plex-layout-main>
@@ -44,20 +58,24 @@
 
         <plex-title titulo="plex-help (type ='info')" size="sm">
             <plex-button size="sm" type="success" label="acción satisfactoria"></plex-button>
-            <plex-help type="info" class="ml-1" titulo="Información sobre este módulo"
-                       subtitulo="A continuación todas las opciones">
+            <plex-help class="ml-1" titulo="Información sobre este panel" subtitulo="A continuación los pasos a seguir">
                 <ol info class="list-group-flush">
-                    <li class="list-group-item">Buscá conceptos SNOMED en el campo de texto del panel lateral
+                    <li>Buscá conceptos SNOMED en el campo de texto del panel lateral
                         (acepta búsquedas
                         parciales)</li>
-                    <li class="list-group-item">Seleccioná el concepto al cual quieras agregar o modificar
+                    <li>Seleccioná el concepto al cual quieras agregar o modificar
                         plantillas</li>
-                    <li class="list-group-item">Completá los campos "Título" y "Texto del procedimiento"</li>
-                    <li class="list-group-item">Opcionalmente podés elegir seleccionar a todos los descendientes
+                    <li>Completá los campos "Título" y "Texto del procedimiento"</li>
+                    <li>Opcionalmente podés elegir seleccionar a todos los descendientes
                         del concepto.</li>
-                    <li class="list-group-item">Hacé click en "Guardar todos" o el botón con el signo <plex-icon
-                                   type="default" size="md" name="check"></plex-icon> para guardar una plantilla
+                    <<<<<<< HEAD <li class="list-group-item">Hacé click en "Guardar todos" o el botón con el signo
+                        <plex-icon type="default" size="md" name="check"></plex-icon> para guardar una plantilla
                         individual</li>
+                        =======
+                        <li>Hacé click en "Guardar todos" o el botón con el signo <i class="mdi mdi-check"></i> para
+                            guardar
+                            una plantilla individual</li>
+                        >>>>>>> c3ad997... feat(demo plex-help): se actualiza con nuevas opciones
                 </ol>
             </plex-help>
         </plex-title>
@@ -76,8 +94,8 @@
         </h6>
         <plex-title titulo="plex-help con botones" size="sm">
             <plex-button size="sm" type="danger" label="acción peligrosa"></plex-button>
-            <plex-help type="help" class="ml-1" titulo="Información sobre este módulo"
-                       subtitulo="A continuación todas las opciones">
+            <<<<<<< HEAD <plex-help type="help" class="ml-1" titulo="Información sobre este módulo"
+                    subtitulo="A continuación todas las opciones">
                 <ol info class="list-group-flush">
                     <li class="list-group-item">Buscá conceptos SNOMED en el campo de texto del panel lateral
                         (acepta búsquedas
@@ -91,7 +109,16 @@
                                    type="default" size="md" name="check"></plex-icon> para guardar una plantilla
                         individual</li>
                 </ol>
-            </plex-help>
+                =======
+                <plex-help class="ml-1" titulo="Ayuda de este panel (invert automático)"
+                           subtitulo="En este contexto se espera un contenido mas bien breve:">
+                    <p>
+                        &mdash;¿Hola? deme el contenido más breve que tenga.<br>
+                        &mdash; ...<br>
+                        &mdash; ¡No, no tan breve!
+                    </p>
+                    >>>>>>> c3ad997... feat(demo plex-help): se actualiza con nuevas opciones
+                </plex-help>
         </plex-title>
 
     </plex-layout-sidebar>

--- a/src/demo/app/help/help.html
+++ b/src/demo/app/help/help.html
@@ -31,7 +31,20 @@
                 </li>
             </ul>
             <hr>
+
+            <plex-title size="sm" titulo="plex-help (cardSize:'half')" class="mb-4">
+                <plex-badge type="info" size="sm">plex-help</plex-badge>
+                <plex-help titulo="size = sm, cardSize = half" size="sm" cardSize="half">
+                    <div class="ml-4 mb-4">
+                        <label>Organización:</label>
+                        prestacion.solicitud.organizacion.nombre
+                    </div>
+                </plex-help>
+            </plex-title>
+            <p>plex-help (cardSize:'half')</p>
+
             <plex-title size="sm" titulo="plex-help" class="mb-4">
+                <plex-badge type="info" size="sm">plex-help</plex-badge>
                 <plex-help titulo="size = sm" size="sm">
                     <div class="ml-4 mb-4">
                         <label>Organización:</label>
@@ -40,7 +53,9 @@
                 </plex-help>
             </plex-title>
             <p>plex-help (size:'sm')</p>
+
             <plex-title size="sm" titulo="plex-help (cardSize:'half')" class="mb-4">
+                <plex-badge type="info" size="sm">plex-help</plex-badge>
                 <plex-help titulo="size = sm, cardSize = half" size="sm" cardSize="half">
                     <div class="ml-4 mb-4">
                         <label>Organización:</label>
@@ -51,7 +66,6 @@
             <p>plex-help (cardSize:'half')</p>
 
         </main>
-
 
     </plex-layout-main>
     <plex-layout-sidebar type="invert">

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -1,9 +1,9 @@
 <plex-layout main="8">
     <plex-layout-main>
         <plex-title main justify titulo="Gestor de agendas">
-            <plex-badge class="ml-1" size="sm" type="success">VALIDADO
+            <plex-badge size="sm" type="success">VALIDADO
             </plex-badge>
-            <plex-help class="ml-1" icon="information" titulo="Información sobre este módulo"
+            <plex-help icon="information" titulo="Información sobre este módulo"
                        subtitulo="A continuación todas las opciones">
                 <ol info class="list-group-flush">
                     <li class="list-group-item">Buscá conceptos SNOMED en el campo de texto del panel lateral

--- a/src/demo/app/item-list/item-list.html
+++ b/src/demo/app/item-list/item-list.html
@@ -1,5 +1,28 @@
 <plex-layout main="8">
     <plex-layout-main>
+        <plex-title size="md" titulo="PLEX LIST">
+            <plex-help type="info">
+                <plex-list height="60%" (scrolled)="onScroll()" size="sm">
+                    <plex-heading>
+                        <b label>Datos importantes</b>
+                        <b label>Parentesco</b>
+                    </plex-heading>
+                    <plex-item *ngFor="let item of lista; let par = even" [selected]="item.selected"
+                               (click)="item.selected = !item.selected">
+                        <plex-bool [(ngModel)]="item.selected" name="activo"></plex-bool>
+                        <plex-icon name="pencil" size="18" type="warning"></plex-icon>
+                        <plex-label [titulo]="item.name" [tituloBold]="par">
+                        </plex-label>
+                        <plex-dropdown icon="dots-vertical" [right]="true" [items]="dropitems">
+                        </plex-dropdown>
+                        <plex-button type="warning" size="sm" icon="clock"></plex-button>
+                        <plex-button type="danger" size="sm" label="Eliminar" (click)="tModelFecha.fechaHora = null">
+                        </plex-button>
+                        <plex-badge type="danger">urgente</plex-badge>
+                    </plex-item>
+                </plex-list>
+            </plex-help>
+        </plex-title>
         <plex-list height="60%" (scrolled)="onScroll()" size="sm">
             <plex-heading>
                 <b label>Datos importantes</b>
@@ -55,6 +78,23 @@
         </plex-list>
     </plex-layout-main>
     <plex-layout-sidebar type="invert">
+        <plex-title size="sm" titulo="Prueba con help">
+            <plex-help titulo="Información sobre este panel" subtitulo="A continuación los pasos a seguir">
+                <ol info class="list-group-flush">
+                    <li>Buscá conceptos SNOMED en el campo de texto del panel lateral
+                        (acepta búsquedas
+                        parciales)</li>
+                    <li>Seleccioná el concepto al cual quieras agregar o modificar
+                        plantillas</li>
+                    <li>Completá los campos "Título" y "Texto del procedimiento"</li>
+                    <li>Opcionalmente podés elegir seleccionar a todos los descendientes
+                        del concepto.</li>
+                    <li>Hacé click en "Guardar todos" o el botón con el signo <i class="mdi mdi-check"></i> para
+                        guardar
+                        una plantilla individual</li>
+                </ol>
+            </plex-help>
+        </plex-title>
         <plex-list size="sm">
             <plex-heading [sticky]="true">
                 <b label>1</b>

--- a/src/lib/app/nav-item.component.ts
+++ b/src/lib/app/nav-item.component.ts
@@ -27,7 +27,7 @@ export class NavItemComponent {
     click() {
         if (!this.opened) {
             event.stopImmediatePropagation();
-            this.plexHelp.toogle();
+            this.plexHelp.toggle();
             this.opened = true;
         }
     }

--- a/src/lib/app/nav-item.component.ts
+++ b/src/lib/app/nav-item.component.ts
@@ -6,7 +6,7 @@ import { PlexHelpComponent } from '../help/help.component';
     selector: 'div[nav-item]',
     template: `
         <ng-content select="plex-icon"></ng-content>
-        <plex-help [icon]="null" (close)="onClose()">
+        <plex-help class="no-icon" [icon]="null" (close)="onClose()">
             <div info>
                 <ng-content></ng-content>
             </div>

--- a/src/lib/css/plex-box.scss
+++ b/src/lib/css/plex-box.scss
@@ -1,5 +1,6 @@
 .plex-box,
 plex-box > DIV {
+    box-sizing: border-box;
     height: 100%;
     background: white;
     display: flex;
@@ -8,9 +9,8 @@ plex-box > DIV {
     padding: ($grid-gutter-width-base / 3);
 
     & > header {
-      margin-bottom: 15px;
-      border-bottom: solid grey 1px;
-      border-bottom: solid #aaa 1px;
+        margin-bottom: 15px;
+        border-bottom: solid #aaa 1px;
     }
 
     & > .plex-box-content {
@@ -18,7 +18,7 @@ plex-box > DIV {
         overflow-y: overlay;
         overflow-x: hidden; // expandir a todo el alto del contenedor
         flex: 1;
-        padding-right: 15px; // Distancia desde el scrollback
+        // padding-right: 15px; // Distancia desde el scrollback
         height: 0;
         // Fix momentaneo
         .plex-box-content {
@@ -40,9 +40,9 @@ plex-box > DIV {
 }
 
 .plex-box-invert {
-      background: $dark-blue;
-      color: white;
-      --heading-background-color: #{$dark-blue};
+    background: $dark-blue;
+    color: white;
+    --heading-background-color: #{$dark-blue};
 
     ::-webkit-scrollbar-thumb {
         background: #e1e1e1;
@@ -61,7 +61,6 @@ plex-box > DIV {
     ::-webkit-scrollbar-track,
     ::-webkit-scrollbar-track:active,
     ::-webkit-scrollbar-track:hover {
-        background: rgba(255,255,255,0.1);
+        background: rgba(255, 255, 255, 0.1);
     }
-
 }

--- a/src/lib/css/plex-box.scss
+++ b/src/lib/css/plex-box.scss
@@ -15,14 +15,21 @@ plex-box > DIV {
 
     & > .plex-box-content {
         clear: both;
-        overflow-y: overlay;
         overflow-x: hidden; // expandir a todo el alto del contenedor
         flex: 1;
-        // padding-right: 15px; // Distancia desde el scrollback
         height: 0;
+
         // Fix momentaneo
         .plex-box-content {
             height: auto;
+        }
+
+        // Ver src/lib/layout/{main,sidebar}.component.ts
+        &.scrollbar {
+            padding-right: 10px;
+            plex-help .card {
+                right: 30px;
+            }
         }
     }
 

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -1,92 +1,104 @@
 plex-help {
-    $top-open: unset;
-    display: inline-block;
-    color: $dark-blue;
-    &.no-icon {
-        .btn-close {
-            display: none;
+  $top-open: 21px;
+  min-width: 30px;
+  display: inline-block;
+
+  &.no-icon {
+    min-width: 0px !important;
+    .btn-close {
+      display: none;
+    }
+    .card.full {
+      min-width: 50vw;
+      left: unset;
+      color: $dark-blue;
+      background: white;
+    }
+  }
+
+  // Contenido del panel/card
+  .card {
+    display: none;
+    border: 0; // reset
+    border-top: 1px solid darken($light-grey, 15%);
+    border-left: 1px solid darken($light-grey, 15%);
+    border-radius: 0.25rem;
+    box-shadow: 2px 2px 5px 0px $dark-grey;
+
+    &.open {
+      display: flex;
+      flex-direction: column;
+
+      max-height: fit-content;
+      background: var(--heading-background-color);
+
+      z-index: 999;
+      position: absolute;
+      right: 15px;
+      left: 15px;
+    }
+
+    &.full {
+      width: auto;
+      height: auto;
+      min-width: 90%;
+    }
+    &.half {
+      width: 50%;
+      height: auto;
+      left: unset;
+    }
+
+    // @Input() titulo:
+    .card-header {
+      height: 50px;
+    }
+
+    // @Input() subtitulo + ng-content:
+    .card-body {
+      transition: all;
+      &.open {
+        height: auto;
+        .toggle-help {
+          right: 60px;
         }
+      }
+      &.closed {
+        height: 0px;
+      }
+      .list-group-item {
+        background: inherit;
+      }
+    }
+  }
+
+  // Botón que abre/cierra
+  .toggle-help {
+    position: initial;
+    right: 15px;
+    top: $top-open;
+    display: inline-block;
+    margin-bottom: -10px;
+
+    &.closed {
+      display: inline-block;
+      position: relative;
+      top: 0;
+      right: 0;
+    }
+    &.open {
+      top: 0;
+      plex-button {
+        z-index: 999;
+      }
     }
 
     plex-button {
-        top: -30px;
-        z-index: 1000;
+      position: relative;
+      top: 1px;
+      right: 0;
+      display: flex;
+      justify-content: flex-end;
     }
-    // Contenido del panel/card
-    .card {
-        position: absolute;
-        display: none;
-        border: 0; // reset
-
-        &.open {
-            box-sizing: border-box;
-            width: 100%;
-            border-top: 1px solid darken($light-grey, 15%);
-            border-left: 1px solid darken($light-grey, 15%);
-            border-radius: 0.25rem;
-            box-shadow: 2px 2px 5px 0px $dark-grey;
-
-            // Display dinámico (none|flex)
-            display: none;
-            flex-direction: column;
-
-            max-height: fit-content;
-            background: var(--heading-background-color);
-            background: $light-grey;
-
-            right: 0;
-            z-index: 999;
-        }
-
-        &.full {
-            width: 90%;
-            height: auto;
-        }
-        &.half {
-            width: 50%;
-            height: auto;
-        }
-
-        // @Input() titulo:
-        .card-header {
-            height: 50px;
-        }
-
-        // @Input() subtitulo + ng-content:
-        .card-body {
-            transition: all;
-            &.open {
-                height: auto;
-                .toggle-help {
-                    right: 60px;
-                }
-            }
-            &.closed {
-                height: 0px;
-            }
-            .list-group-item {
-                background: inherit;
-            }
-        }
-    }
-
-    // Botón que abre/cierra
-    .toggle-help {
-        position: absolute;
-        right: 0;
-        display: inline-block;
-        box-sizing: border-box;
-
-        height: auto;
-
-        &.closed {
-            display: inline-block;
-            position: relative;
-            top: 0;
-            right: 0;
-        }
-        &.open {
-            left: 15px;
-        }
-    }
+  }
 }

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -12,7 +12,6 @@ plex-help {
         &.open {
             box-sizing: border-box;
             width: 100%;
-            min-width: 40vw;
             border-top: 1px solid darken($light-grey, 15%);
             border-left: 1px solid darken($light-grey, 15%);
             border-radius: 0.25rem;
@@ -31,7 +30,7 @@ plex-help {
         }
 
         &.full {
-            width: auto;
+            width: 90%;
             height: auto;
         }
         &.half {
@@ -66,8 +65,8 @@ plex-help {
     .toggle-help {
         position: absolute;
         right: 0;
-        top: $top-open;
         display: inline-block;
+        box-sizing: border-box;
 
         height: auto;
 
@@ -75,8 +74,11 @@ plex-help {
             position: relative;
             top: 0;
             right: 0;
+            display: inline-block;
             display: flex;
             justify-content: flex-end;
+            align-items: flex-end;
+            max-height: 36px;
         }
 
         &.closed {
@@ -88,7 +90,6 @@ plex-help {
         &.open {
             left: 15px;
             plex-button {
-                top: 25px;
                 z-index: 1000;
             }
         }

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -12,9 +12,7 @@ plex-help {
         &.open {
             display: flex;
             flex-direction: column;
-            width: auto;
-            height: auto;
-            background: white;
+            background: var(--heading-background-color);
             z-index: 999;
             position: absolute;
         &.full {

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -2,6 +2,11 @@ plex-help {
     $top-open: unset;
     display: inline-block;
     color: $dark-blue;
+    &.no-icon {
+        .btn-close {
+            display: none;
+        }
+    }
 
     // Contenido del panel/card
     .card {

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -8,6 +8,10 @@ plex-help {
         }
     }
 
+    plex-button {
+        top: -30px;
+        z-index: 1000;
+    }
     // Contenido del panel/card
     .card {
         position: absolute;
@@ -75,17 +79,6 @@ plex-help {
 
         height: auto;
 
-        plex-button {
-            position: relative;
-            top: 0;
-            right: 0;
-            display: inline-block;
-            display: flex;
-            justify-content: flex-end;
-            align-items: flex-end;
-            max-height: 36px;
-        }
-
         &.closed {
             display: inline-block;
             position: relative;
@@ -94,9 +87,6 @@ plex-help {
         }
         &.open {
             left: 15px;
-            plex-button {
-                z-index: 1000;
-            }
         }
     }
 }

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -17,9 +17,16 @@ plex-help {
             background: white;
             z-index: 999;
             position: absolute;
-            right: 30px;
+        &.full {
             left: 30px;
+            width: auto;
+            height: auto;
         }
+        &.half {
+            width: 50%;
+            height: auto;
+        }
+
         .card-header {
             height: 50px;
         }

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -1,6 +1,9 @@
 plex-help {
     $top-open: 21px;
+    min-width: 30px;
+    display: inline-block;
 
+    // Contenido del panel/card
     .card {
         display: none;
         border: 0; // reset
@@ -12,9 +15,15 @@ plex-help {
         &.open {
             display: flex;
             flex-direction: column;
+
+            max-height: fit-content;
             background: var(--heading-background-color);
+
             z-index: 999;
             position: absolute;
+            right: 34px;
+        }
+
         &.full {
             left: 30px;
             width: auto;
@@ -25,9 +34,12 @@ plex-help {
             height: auto;
         }
 
+        // @Input() titulo:
         .card-header {
             height: 50px;
         }
+
+        // @Input() subtitulo + ng-content:
         .card-body {
             transition: all;
             &.open {
@@ -39,73 +51,40 @@ plex-help {
             &.closed {
                 height: 0px;
             }
+            .list-group-item {
+                background: inherit;
+            }
         }
     }
 
-    .toggle-help,
-    .toggle-info {
+    // Botón que abre/cierra
+    .toggle-help {
+        position: initial;
+        right: 15px;
+        top: $top-open;
+        display: inline-block;
+        min-width: 30px;
+        height: auto;
+
         &.closed {
             display: inline-block;
             position: relative;
+            top: 0;
             right: 0;
         }
         &.open {
+            top: 0;
             plex-button {
                 z-index: 999;
             }
         }
+
         plex-button {
             position: relative;
             top: 1px;
             right: 0;
             display: flex;
             justify-content: flex-end;
-        }
-    }
-    .toggle-help,
-    .toggle-info {
-        position: absolute;
-        right: 15px;
-        top: $top-open;
-        &.closed {
-            top: 0;
-        }
-    }
-    .toggle-help {
-        position: initial;
-        display: inline-block;
-        // min-width: 42px;
-        height: auto;
-        &.open {
-            top: 0;
-        }
-    }
-
-    .jumbotron {
-        padding: 15px 30px;
-        border-top: 1px solid darken($light-grey, 15%);
-        border-left: 1px solid darken($light-grey, 15%);
-        color: black;
-
-        plex-button {
-            position: absolute;
-            top: -1px;
-            right: 0px;
-        }
-        &.open {
-            position: absolute;
-            right: 15px;
-            top: $top-open;
-            z-index: 998;
-            width: auto;
-            border-radius: 0.25rem;
-            box-shadow: 2px 2px 5px 0px $dark-grey;
-            min-width: 41vw;
-            max-height: 69vh;
-            overflow-y: scroll;
-        }
-        &.closed {
-            height: 0px;
         }
     }
 }

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -1,31 +1,36 @@
 plex-help {
-    $top-open: 21px;
-    min-width: 30px;
+    $top-open: unset;
     display: inline-block;
+    color: $dark-blue;
 
     // Contenido del panel/card
     .card {
+        position: absolute;
         display: none;
         border: 0; // reset
-        border-top: 1px solid darken($light-grey, 15%);
-        border-left: 1px solid darken($light-grey, 15%);
-        border-radius: 0.25rem;
-        box-shadow: 2px 2px 5px 0px $dark-grey;
 
         &.open {
-            display: flex;
+            box-sizing: border-box;
+            width: 100%;
+            min-width: 40vw;
+            border-top: 1px solid darken($light-grey, 15%);
+            border-left: 1px solid darken($light-grey, 15%);
+            border-radius: 0.25rem;
+            box-shadow: 2px 2px 5px 0px $dark-grey;
+
+            // Display dinámico (none|flex)
+            display: none;
             flex-direction: column;
 
             max-height: fit-content;
             background: var(--heading-background-color);
+            background: $light-grey;
 
+            right: 0;
             z-index: 999;
-            position: absolute;
-            right: 34px;
         }
 
         &.full {
-            left: 30px;
             width: auto;
             height: auto;
         }
@@ -59,12 +64,20 @@ plex-help {
 
     // Botón que abre/cierra
     .toggle-help {
-        position: initial;
-        right: 15px;
+        position: absolute;
+        right: 0;
         top: $top-open;
         display: inline-block;
-        min-width: 30px;
+
         height: auto;
+
+        plex-button {
+            position: relative;
+            top: 0;
+            right: 0;
+            display: flex;
+            justify-content: flex-end;
+        }
 
         &.closed {
             display: inline-block;
@@ -73,18 +86,11 @@ plex-help {
             right: 0;
         }
         &.open {
-            top: 0;
+            left: 15px;
             plex-button {
-                z-index: 999;
+                top: 25px;
+                z-index: 1000;
             }
-        }
-
-        plex-button {
-            position: relative;
-            top: 1px;
-            right: 0;
-            display: flex;
-            justify-content: flex-end;
         }
     }
 }

--- a/src/lib/css/plex-hint.scss
+++ b/src/lib/css/plex-hint.scss
@@ -1,0 +1,3 @@
+plex-hint {
+    width: 8px;
+}

--- a/src/lib/css/plex-title.scss
+++ b/src/lib/css/plex-title.scss
@@ -25,7 +25,7 @@
         }
     }
     .title-content {
-        height: 30px;
+        height: 31px;
         max-height: 36px;
         display: flex;
         align-items: center;

--- a/src/lib/css/plex-title.scss
+++ b/src/lib/css/plex-title.scss
@@ -1,7 +1,7 @@
 .plex-title {
     margin-bottom: 3px;
     border-bottom: solid $dark-grey 1px;
-    
+
     width: 100%;
     .plex-title-label {
         font-size: 1.8em;
@@ -11,21 +11,24 @@
         &.sm {
             font-size: 1.4em;
         }
-    
+
         &.md {
             font-size: 1.6em;
         }
-    
+
         &.lg {
             font-size: 1.8em;
         }
-    
+
         &.xl {
             font-size: 2em;
         }
     }
     .title-content {
+        height: 30px;
         max-height: 36px;
+        display: flex;
+        align-items: center;
     }
     &.size-sm {
         flex-wrap: wrap;
@@ -40,4 +43,3 @@ header {
         border-bottom: none !important;
     }
 }
-

--- a/src/lib/css/plex-wrapper.scss
+++ b/src/lib/css/plex-wrapper.scss
@@ -28,7 +28,7 @@ plex-wrapper  {
         }
     }
 
-    plex-button.btn-toogle {
+    plex-button.btn-toggle {
         position: absolute;
         top: 0;
         right: 0;

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -3,6 +3,7 @@ import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@
 @Component({
     selector: 'plex-help',
     template: `
+    <plex-button class="btn-close" *ngIf="!closed" type="danger" size="sm" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
     <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}">
         <plex-button *ngIf="!closed" type="danger" size="sm" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
         <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -5,7 +5,7 @@ import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core
     template: `
     <div class="toggle-{{ type }}" [ngClass]="{'closed': closed, 'open': !closed}">
         <plex-button *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
-        <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'informacion' : 'help-circle'" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
+        <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [title]="title" [icon]="type === 'info'? 'informacion' : 'help'" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
         <plex-button *ngIf="content && closed && tituloBoton" type="info" [size]="size" [label]="tituloBoton" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
     </div>
     <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
@@ -13,31 +13,28 @@ import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core
             <div class="card-header">
                 <h5>{{ titulo }}</h5>
             </div>
-            <div class="card-body">
+            <div class="card-body m-3">
+                <h6 *ngIf="type === 'info' && subtitulo">{{ subtitulo }}</h6>
                 <ng-content></ng-content>
             </div>
         </ng-container>
     </div>
-    <ng-container *ngIf="!closed && type === 'info'">
-        <div class="jumbotron {{ type }}" [ngClass]="{'open': !closed}" (click)="$event.stopImmediatePropagation();">
-            <h1 class="display-6">{{ titulo }}</h1>
-            <p class="lead" *ngIf="subtitulo"><b>{{ subtitulo }}</b></p>
-            <ng-content select="[info]"></ng-content>
-        </div>
-    </ng-container>
     `
 })
 export class PlexHelpComponent {
 
-    @Input() type: 'info' | 'help' = 'info';
 
     @Input() titulo = '';
 
     @Input() subtitulo: string;
 
+    @Input() size: 'sm' | 'md' = 'sm';
+
     @Input() cardSize: 'full' | 'half' = 'full';
 
     @Input() title: string;
+
+    @Input() type: 'info' | 'help' = 'help'; // deprecated
 
     @Input() tituloBoton = '';
 

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -4,7 +4,7 @@ import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@
     selector: 'plex-help',
     template: `
     <plex-button class="btn-close" *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
-    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();">
+    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [icon]="type === 'info'? 'informacion' : 'help'" (click)="toggle();$event.stopImmediatePropagation();">
     </plex-button>
     <plex-button class="btn-open" *ngIf="content && closed && tituloBoton" type="info" [size]="size" [label]="tituloBoton" (click)="toggle();$event.stopImmediatePropagation();">
     </plex-button>

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -4,9 +4,8 @@ import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@
     selector: 'plex-help',
     template: `
     <plex-button class="btn-close" *ngIf="!closed" type="danger" size="sm" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
+    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
     <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}">
-        <plex-button *ngIf="!closed" type="danger" size="sm" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
-        <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
         <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
             <ng-container *ngIf="!closed">
                 <div class="card-body m-3">
@@ -56,7 +55,7 @@ export class PlexHelpComponent {
 
         const card = this.el.nativeElement.querySelector('.card');
         const toggle = this.el.nativeElement.querySelector('.toggle-help');
-        const btn = toggle.querySelector('plex-button');
+        const btn = this.el.nativeElement.querySelector('.btn-open');
 
         // Reset posicionamiento
         this.renderer.removeStyle(toggle, 'right');
@@ -69,16 +68,18 @@ export class PlexHelpComponent {
             let top = window.scrollY;
 
             if (btn) {
+                this.renderer.removeStyle(btn, 'top');
+                this.renderer.setStyle(btn, 'display', 'inline-block');
+
                 // Para uso normal, con botón/icon de plex-help
                 const btnRect = btn.getBoundingClientRect();
                 top = btnRect.top - btnRect.height;
-                this.renderer.setStyle(card, 'top', `0`);
                 right += 20;
+
             } else {
                 // Para uso con nav-item, sin botón/icon de plex-help
                 top += 45;
                 this.renderer.setStyle(card, 'width', '45vw');
-
             }
             // Posicionamiento
             this.renderer.setStyle(toggle, 'top', `${top}px`);

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -8,7 +8,7 @@ import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core
         <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'informacion' : 'help-circle'" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
         <plex-button *ngIf="content && closed && tituloBoton" type="info" [size]="size" [label]="tituloBoton" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
     </div>
-    <div class="card {{ type }}" [ngClass]="{'open': !closed}" *ngIf="type === 'help'" (click)="$event.stopImmediatePropagation();">
+    <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
         <ng-container *ngIf="!closed">
             <div class="card-header">
                 <h5>{{ titulo }}</h5>
@@ -35,7 +35,7 @@ export class PlexHelpComponent {
 
     @Input() subtitulo: string;
 
-    @Input() size: 'sm' | 'md' | 'lg' = 'sm';
+    @Input() cardSize: 'full' | 'half' = 'full';
 
     @Input() title: string;
 

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -1,23 +1,20 @@
-import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@angular/core';
 
 @Component({
     selector: 'plex-help',
     template: `
-    <div class="toggle-{{ type }}" [ngClass]="{'closed': closed, 'open': !closed}">
-        <plex-button *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
-        <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [title]="title" [icon]="type === 'info'? 'informacion' : 'help'" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
-        <plex-button *ngIf="content && closed && tituloBoton" type="info" [size]="size" [label]="tituloBoton" (click)="toogle();$event.stopImmediatePropagation();"></plex-button>
-    </div>
-    <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
-        <ng-container *ngIf="!closed">
-            <div class="card-header">
-                <h5>{{ titulo }}</h5>
-            </div>
-            <div class="card-body m-3">
-                <h6 *ngIf="type === 'info' && subtitulo">{{ subtitulo }}</h6>
-                <ng-content></ng-content>
-            </div>
-        </ng-container>
+    <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}">
+        <plex-button *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
+        <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
+        <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
+            <ng-container *ngIf="!closed">
+                <div class="card-body m-3">
+                    <plex-title *ngIf="titulo" size="sm" [titulo]="titulo"></plex-title>
+                    <h6 *ngIf="type === 'info' && subtitulo">{{ subtitulo }}</h6>
+                    <ng-content></ng-content>
+                </div>
+            </ng-container>
+        </div>
     </div>
     `
 })
@@ -48,21 +45,43 @@ export class PlexHelpComponent {
 
     closed = true;
 
-    constructor(private renderer: Renderer2) { }
+    constructor(private renderer: Renderer2, private el: ElementRef) { }
 
     get content() {
         return (this.icon && this.icon.length > 0) || (this.tituloBoton && this.tituloBoton.length > 0);
     }
 
-    public toogle() {
+    public toggle() {
+
+        const card = this.el.nativeElement.querySelector('.card');
+        const toggle = this.el.nativeElement.querySelector('.toggle-help');
+        const btn = toggle.querySelector('plex-button');
+
+        const toggleRect = toggle.getBoundingClientRect();
+        const cardRect = card.getBoundingClientRect();
+
         this.closed = !this.closed;
         if (!this.closed) {
+            const right = cardRect.right - cardRect.left - cardRect.width + toggleRect.width;
+            let top;
+            if (btn) {
+                const btnRect = btn.getBoundingClientRect();
+                top = toggleRect.top - (btnRect.height * 2);
+            } else {
+                top = 21;
+            }
+            this.renderer.setStyle(toggle, 'top', `${top}px`);
+            this.renderer.setStyle(toggle, 'right', `${right}px`);
+            this.renderer.setStyle(card, 'display', 'flex');
             this.open.emit();
             this.unlisten = this.renderer.listen('document', 'click', (event) => {
-                this.toogle();
+                this.toggle();
                 this.unlisten();
             });
         } else {
+            this.renderer.removeStyle(toggle, 'right');
+            this.renderer.removeStyle(toggle, 'top');
+
             this.close.emit();
             if (this.unlisten) {
                 this.unlisten();

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -4,7 +4,7 @@ import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@
     selector: 'plex-help',
     template: `
     <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}">
-        <plex-button *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
+        <plex-button *ngIf="!closed" type="danger" size="sm" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
         <plex-button *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
         <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
             <ng-container *ngIf="!closed">
@@ -57,30 +57,39 @@ export class PlexHelpComponent {
         const toggle = this.el.nativeElement.querySelector('.toggle-help');
         const btn = toggle.querySelector('plex-button');
 
-        const toggleRect = toggle.getBoundingClientRect();
-        const cardRect = card.getBoundingClientRect();
+        // Reset posicionamiento
+        this.renderer.removeStyle(toggle, 'right');
+        this.renderer.removeStyle(toggle, 'top');
 
         this.closed = !this.closed;
         if (!this.closed) {
-            const right = cardRect.right - cardRect.left - cardRect.width + toggleRect.width;
-            let top;
+
+            let right = window.scrollX;
+            let top = window.scrollY;
+
             if (btn) {
+                // Para uso normal, con botón/icon de plex-help
                 const btnRect = btn.getBoundingClientRect();
-                top = toggleRect.top - (btnRect.height * 2);
+                top = btnRect.top - btnRect.height;
+                this.renderer.setStyle(card, 'top', `0`);
+                right += 20;
             } else {
-                top = 21;
+                // Para uso con nav-item, sin botón/icon de plex-help
+                top += 45;
+                this.renderer.setStyle(card, 'width', '45vw');
+
             }
+            // Posicionamiento
             this.renderer.setStyle(toggle, 'top', `${top}px`);
             this.renderer.setStyle(toggle, 'right', `${right}px`);
             this.renderer.setStyle(card, 'display', 'flex');
+
             this.open.emit();
             this.unlisten = this.renderer.listen('document', 'click', (event) => {
                 this.toggle();
                 this.unlisten();
             });
         } else {
-            this.renderer.removeStyle(toggle, 'right');
-            this.renderer.removeStyle(toggle, 'top');
 
             this.close.emit();
             if (this.unlisten) {

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -3,8 +3,11 @@ import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@
 @Component({
     selector: 'plex-help',
     template: `
-    <plex-button class="btn-close" *ngIf="!closed" type="danger" size="sm" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
-    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" title="{{ title }}" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
+    <plex-button class="btn-close" *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
+    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [icon]="type === 'info'? 'information-variant' : 'help'" (click)="toggle();$event.stopImmediatePropagation();">
+    </plex-button>
+    <plex-button class="btn-open" *ngIf="content && closed && tituloBoton" type="info" [size]="size" [label]="tituloBoton" (click)="toggle();$event.stopImmediatePropagation();">
+    </plex-button>
     <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}">
         <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
             <ng-container *ngIf="!closed">

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -4,7 +4,7 @@ import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@
     selector: 'plex-help',
     template: `
     <plex-button class="btn-close" *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
-    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [icon]="type === 'info'? 'informacion' : 'help'" (click)="toggle();$event.stopImmediatePropagation();">
+    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [icon]="icon" (click)="toggle();$event.stopImmediatePropagation();">
     </plex-button>
     <plex-button class="btn-open" *ngIf="content && closed && tituloBoton" type="info" [size]="size" [label]="tituloBoton" (click)="toggle();$event.stopImmediatePropagation();">
     </plex-button>
@@ -38,7 +38,7 @@ export class PlexHelpComponent {
 
     @Input() tituloBoton = '';
 
-    @Input() icon: 'help-circle' | 'informacion' = 'help-circle';
+    @Input() icon = 'help';
 
     @Output() close = new EventEmitter();
 
@@ -56,38 +56,8 @@ export class PlexHelpComponent {
 
     public toggle() {
 
-        const card = this.el.nativeElement.querySelector('.card');
-        const toggle = this.el.nativeElement.querySelector('.toggle-help');
-        const btn = this.el.nativeElement.querySelector('.btn-open');
-
-        // Reset posicionamiento
-        this.renderer.removeStyle(toggle, 'right');
-        this.renderer.removeStyle(toggle, 'top');
-
         this.closed = !this.closed;
         if (!this.closed) {
-
-            let right = window.scrollX;
-            let top = window.scrollY;
-
-            if (btn) {
-                this.renderer.removeStyle(btn, 'top');
-                this.renderer.setStyle(btn, 'display', 'inline-block');
-
-                // Para uso normal, con botón/icon de plex-help
-                const btnRect = btn.getBoundingClientRect();
-                top = btnRect.top - btnRect.height;
-                right += 20;
-
-            } else {
-                // Para uso con nav-item, sin botón/icon de plex-help
-                top += 45;
-                this.renderer.setStyle(card, 'width', '45vw');
-            }
-            // Posicionamiento
-            this.renderer.setStyle(toggle, 'top', `${top}px`);
-            this.renderer.setStyle(toggle, 'right', `${right}px`);
-            this.renderer.setStyle(card, 'display', 'flex');
 
             this.open.emit();
             this.unlisten = this.renderer.listen('document', 'click', (event) => {

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@angular/core';
+import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core';
 
 @Component({
     selector: 'plex-help',
@@ -48,7 +48,7 @@ export class PlexHelpComponent {
 
     closed = true;
 
-    constructor(private renderer: Renderer2, private el: ElementRef) { }
+    constructor(private renderer: Renderer2) { }
 
     get content() {
         return (this.icon && this.icon.length > 0) || (this.tituloBoton && this.tituloBoton.length > 0);

--- a/src/lib/layout/main.component.ts
+++ b/src/lib/layout/main.component.ts
@@ -1,35 +1,34 @@
-import { Component, Input, ElementRef, AfterViewInit, HostListener } from '@angular/core';
+import { Component, Input, ElementRef, AfterViewInit, HostListener, Renderer2, ViewChild } from '@angular/core';
 
 @Component({
     selector: 'plex-layout-main',
     template: `
-        <div class="plex-box" [ngClass]="{'plex-box-invert': type == 'invert'}">
-          <ng-content select="header"></ng-content>
-          <ng-content select="plex-title[main]"></ng-content>
-        <div class="plex-box-content" [ngClass]="{'scrollbar': scrollBarPresent}">
-              <ng-content></ng-content>
-          </div>
-        </div>
+        <div class="plex-box" [class.plex-box-invert]="type == 'invert'">
+            <ng-content select="header"></ng-content>
+            <ng-content select="plex-title[main]"></ng-content>
+            <div #content class="plex-box-content" >
+                <ng-content></ng-content>
+            </div>
+            </div>
     `,
 })
 export class PlexLayoutMainComponent implements AfterViewInit {
-    @Input() type = '';
-    scrollBarPresent: boolean;
-    content: any;
+    @ViewChild('content', { read: ElementRef, static: false }) content: ElementRef;
 
-    constructor(private el: ElementRef) {
+    @Input() type = '';
+
+    constructor(private render: Renderer2) {
     }
 
     ngAfterViewInit() {
-        this.content = this.el.nativeElement.querySelector('.plex-box-content');
         this.checkScroll();
     }
 
     checkScroll() {
-        if (this.content.scrollHeight > this.content.clientHeight) {
-            this.scrollBarPresent = true;
+        if (this.content.nativeElement.scrollHeight > this.content.nativeElement.clientHeight) {
+            this.render.addClass(this.content.nativeElement, 'scrolbar');
         } else {
-            this.scrollBarPresent = false;
+            this.render.removeClass(this.content.nativeElement, 'scrolbar');
         }
     }
 

--- a/src/lib/layout/main.component.ts
+++ b/src/lib/layout/main.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ElementRef, AfterViewInit, HostListener } from '@angular/core';
 
 @Component({
     selector: 'plex-layout-main',
@@ -6,15 +6,36 @@ import { Component, Input } from '@angular/core';
         <div class="plex-box" [ngClass]="{'plex-box-invert': type == 'invert'}">
           <ng-content select="header"></ng-content>
           <ng-content select="plex-title[main]"></ng-content>
-          <div class="plex-box-content">
+        <div class="plex-box-content" [ngClass]="{'scrollbar': scrollBarPresent}">
               <ng-content></ng-content>
           </div>
         </div>
     `,
 })
-export class PlexLayoutMainComponent {
+export class PlexLayoutMainComponent implements AfterViewInit {
     @Input() type = '';
-    constructor() {
+    scrollBarPresent: boolean;
+    content: any;
 
+    constructor(private el: ElementRef) {
     }
+
+    ngAfterViewInit() {
+        this.content = this.el.nativeElement.querySelector('.plex-box-content');
+        this.checkScroll();
+    }
+
+    checkScroll() {
+        if (this.content.scrollHeight > this.content.clientHeight) {
+            this.scrollBarPresent = true;
+        } else {
+            this.scrollBarPresent = false;
+        }
+    }
+
+    @HostListener('window:resize', ['event'])
+    onResize() {
+        this.checkScroll();
+    }
+
 }

--- a/src/lib/layout/sidebar.component.ts
+++ b/src/lib/layout/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ElementRef, HostListener, AfterViewInit } from '@angular/core';
 
 @Component({
     selector: 'plex-layout-sidebar',
@@ -6,15 +6,35 @@ import { Component, Input } from '@angular/core';
     <div class="plex-box" [ngClass]="{'plex-box-invert': type == 'invert'}">
         <ng-content select="header"></ng-content>
         <ng-content select="plex-title[main]"></ng-content>
-        <div class="plex-box-content">
+        <div class="plex-box-content" [ngClass]="{'scrollbar': scrollBarPresent}">
             <ng-content></ng-content>
         </div>
     </div>
     `,
 })
-export class PlexLayoutSidebarComponent {
+export class PlexLayoutSidebarComponent implements AfterViewInit {
     @Input() type = '';
-    constructor() {
+    scrollBarPresent: boolean;
+    content: any;
 
+    constructor(private el: ElementRef) {
+    }
+
+    ngAfterViewInit() {
+        this.content = this.el.nativeElement.querySelector('.plex-box-content');
+        this.checkScroll();
+    }
+
+    checkScroll() {
+        if (this.content.scrollHeight > this.content.clientHeight) {
+            this.scrollBarPresent = true;
+        } else {
+            this.scrollBarPresent = false;
+        }
+    }
+
+    @HostListener('window:resize', ['event'])
+    onResize() {
+        this.checkScroll();
     }
 }

--- a/src/lib/layout/sidebar.component.ts
+++ b/src/lib/layout/sidebar.component.ts
@@ -1,35 +1,33 @@
-import { Component, Input, ElementRef, HostListener, AfterViewInit } from '@angular/core';
+import { Component, Input, ElementRef, HostListener, AfterViewInit, ViewChild, Renderer2 } from '@angular/core';
 
 @Component({
     selector: 'plex-layout-sidebar',
     template: `
-    <div class="plex-box" [ngClass]="{'plex-box-invert': type == 'invert'}">
+    <div class="plex-box" [class.plex-box-invert]="type == 'invert'">
         <ng-content select="header"></ng-content>
         <ng-content select="plex-title[main]"></ng-content>
-        <div class="plex-box-content" [ngClass]="{'scrollbar': scrollBarPresent}">
+        <div #content class="plex-box-content"  >
             <ng-content></ng-content>
         </div>
     </div>
     `,
 })
 export class PlexLayoutSidebarComponent implements AfterViewInit {
+    @ViewChild('content', { read: ElementRef, static: false }) content: ElementRef;
     @Input() type = '';
-    scrollBarPresent: boolean;
-    content: any;
 
-    constructor(private el: ElementRef) {
+    constructor(private render: Renderer2) {
     }
 
     ngAfterViewInit() {
-        this.content = this.el.nativeElement.querySelector('.plex-box-content');
         this.checkScroll();
     }
 
     checkScroll() {
-        if (this.content.scrollHeight > this.content.clientHeight) {
-            this.scrollBarPresent = true;
+        if (this.content.nativeElement.scrollHeight > this.content.nativeElement.clientHeight) {
+            this.render.addClass(this.content.nativeElement, 'scrolbar');
         } else {
-            this.scrollBarPresent = false;
+            this.render.removeClass(this.content.nativeElement, 'scrolbar');
         }
     }
 

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -102,6 +102,7 @@ $mdi-font-path: "~@mdi/font/fonts/";
 @import "css/plex-label";
 @import "css/plex-title";
 @import "css/plex-help";
+@import "css/plex-hint";
 @import "css/plex-modal";
 @import "css/plex-detail";
 @import "css/plex-options";

--- a/src/lib/wrapper/wrapper.component.ts
+++ b/src/lib/wrapper/wrapper.component.ts
@@ -5,8 +5,8 @@ import { Plex } from '../core/service';
     selector: 'plex-wrapper',
     template: `
     <section class="hidden" [class.desplegado]="desplegado" responsive>
-        <plex-button class="btn-toogle" type="info" size="sm" *ngIf="hasCollapse"
-            [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toogle()">
+        <plex-button class="btn-toggle" type="info" size="sm" *ngIf="hasCollapse"
+            [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toggle()">
         </plex-button>
         <ng-content></ng-content>
         <ng-content select="[collapse]"></ng-content>
@@ -34,7 +34,7 @@ export class PlexWrapperComponent implements AfterViewInit {
         this.ref.detectChanges();
     }
 
-    toogle() {
+    toggle() {
         this.desplegado = !this.desplegado;
         this.change.emit(this.desplegado);
     }


### PR DESCRIPTION
Se "mergearon" los tipos info y help, ahora con diferencias mínimas:
- Los types ("help" o "info") determinan el ícono que los identifica
- Sólo el tipo "info" soporta subtítulo

Se incorporó funcionalidad para optimizar tamaño:
- cardSize ("full" o "half") posibilita ocupar sólo el 50% del ancho si el contenido es reducido.

Además se corrigieron los siguientes problemas:
- Posicionamiento de la ventana/botón toggle
- Falla al visualizar el contenido en modo invert (sidebar)