### PR TITLE
feat(plex-tabs): posibilita convivencia con badge y button

### DIFF
--- a/cypress/integration/tabs.js
+++ b/cypress/integration/tabs.js
@@ -1,0 +1,22 @@
+/// <reference types="Cypress" />
+
+context('tabs', () => {
+    before(() => {
+        cy.eyesOpen({ appName: 'PLEX', testName: 'plex-tabs' });
+        cy.visit('/tabs');
+    });
+
+    it('abre y cierra tabs', () => {
+
+        cy.get('plex-layout plex-tabs:first')
+
+        cy.eyesCheckWindow('tab selected');
+
+        cy.plexTab('Tab 2')
+
+        cy.plexButtonIcon('chevron-right').click();
+
+        cy.eyesClose();
+
+    });
+});

--- a/cypress/integration/tabs.js
+++ b/cypress/integration/tabs.js
@@ -6,7 +6,7 @@ context('tabs', () => {
         cy.visit('/tabs');
     });
 
-    it('abre y cierra tabs', () => {
+    it('navega tabs', () => {
 
         cy.get('plex-layout plex-tabs:first')
 
@@ -14,7 +14,11 @@ context('tabs', () => {
 
         cy.plexTab('Tab 2')
 
+        cy.get('plex-layout plex-tabs:first plex-tab:nth-child(2) > div.alert.alert-warning').should('contain.text', 'Contenido 2');
+
         cy.plexButtonIcon('chevron-right').click();
+
+        cy.get('plex-layout plex-tabs:first plex-tab:nth-child(3) > div.alert.alert-danger').should('contain.text', 'Contenido 3');
 
         cy.eyesClose();
 

--- a/src/demo/app/tabs/tabs.component.ts
+++ b/src/demo/app/tabs/tabs.component.ts
@@ -32,6 +32,12 @@ export class TabsDemoComponent {
         }
     }
 
+    public previous() {
+        if (this.activo > 0) {
+            this.activo = this.activo - 1;
+        }
+    }
+
     public cambio(value: number) {
         this.plex.toast('info', 'Tab seleccionado: ' + value);
         this.activo = value;

--- a/src/demo/app/tabs/tabs.component.ts
+++ b/src/demo/app/tabs/tabs.component.ts
@@ -1,13 +1,14 @@
 import { Plex } from './../../../lib/core/service';
-import { Component, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { from, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { DropdownItem } from '../../../lib/dropdown/dropdown-item.inteface';
 
+
 @Component({
     templateUrl: 'tabs.html',
 })
-export class TabsDemoComponent {
+export class TabsDemoComponent implements OnInit {
     public activo = 1;
     public activoDinamico = 0;
     public mostrar = true;
@@ -23,6 +24,9 @@ export class TabsDemoComponent {
 
     public items: DropdownItem[];
 
+    constructor(private plex: Plex) {
+    }
+
     ngOnInit() {
         this.items = [
             { label: 'Ir a inicio', icon: 'dna', route: '/incio' },
@@ -31,11 +35,6 @@ export class TabsDemoComponent {
             { label: 'Item con handler', icon: 'wrench', handler: (() => { alert('Este es un handler'); }) }
         ];
     }
-
-
-    constructor(private plex: Plex) {
-    }
-
 
     public next() {
         this.activo++;

--- a/src/demo/app/tabs/tabs.component.ts
+++ b/src/demo/app/tabs/tabs.component.ts
@@ -2,6 +2,7 @@ import { Plex } from './../../../lib/core/service';
 import { Component, OnDestroy } from '@angular/core';
 import { from, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { DropdownItem } from '../../../lib/dropdown/dropdown-item.inteface';
 
 @Component({
     templateUrl: 'tabs.html',
@@ -15,11 +16,22 @@ export class TabsDemoComponent {
         { label: 'amplifier', icon: 'amplifier', color: 'trastorno' },
         { label: 'amazon', icon: 'amazon', color: 'default' }
     ];
-
     public contenidoAsync = of([1, 2, 3]).pipe(
         // tslint:disable-next-line:no-console
         tap(console.log)
     );
+
+    public items: DropdownItem[];
+
+    ngOnInit() {
+        this.items = [
+            { label: 'Ir a inicio', icon: 'dna', route: '/incio' },
+            { label: 'Ir a ruta inexistente', icon: 'flag', route: '/ruta-rota' },
+            { divider: true },
+            { label: 'Item con handler', icon: 'wrench', handler: (() => { alert('Este es un handler'); }) }
+        ];
+    }
+
 
     constructor(private plex: Plex) {
     }

--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -51,6 +51,17 @@
                 <plex-badge type="warning" size="sm">badge warning</plex-badge>
                 <plex-button type="info" size="sm" label="test"></plex-button>
                 <plex-button type="warning" size="sm" label="test"></plex-button>
+                <plex-help type="help" titulo="Ayuda de este panel" size="sm">
+                    <div class="ml-4 mb-4" *plHelp>
+                        <label>Organización:</label>
+                        prestacion.solicitud.organizacion.nombre
+                        <label>Fecha:</label>
+                        prestacion.solicitud.fecha | date
+                        <label>Prestación de origen:</label>
+                        prestacion.solicitud.prestacionOrigen
+                        {{ asyncContent | async | json }}
+                    </div>
+                </plex-help>
             </plex-tabs>
         </section>
     </plex-layout-main>

--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -1,56 +1,77 @@
 <plex-layout main="8">
-	<plex-layout-main>
-		<plex-title titulo="Tabs estáticos">
-			<plex-button (click)="next()" label="Siguiente tab"></plex-button>
-		</plex-title>
-		<pre>Tab activo: {{activo}}</pre>
-		<plex-tabs [activeIndex]="activo" (change)="cambio($event)">
-			<plex-tab label="Tab 1" color="procedimiento">
-				<div class="alert alert-info">
-					Contenido 1
-				</div>
-			</plex-tab>
-			<plex-tab *ngIf="mostrar" label="Tab 2" icon="account">
-				<div class="alert alert-warning">
-					Contenido 2
-				</div>
-			</plex-tab>
-			<plex-tab icon="history">
-				<div class="alert alert-danger" *plTab="5000">
-					Contenido 3
-					<span *ngFor="let item of contenidoAsync | async"> {{ item }} </span>
-				</div>
-			</plex-tab>
-		</plex-tabs>
-		<plex-title titulo="Tabs dinámicos">
-			<plex-button (click)="add()" label="Agregar" type="success"></plex-button>
-		</plex-title>
-		<plex-tabs [activeIndex]="activoDinamico" (close)="close($event)">
-			<plex-tab *ngFor="let item of tabs" [label]="item.label" [icon]="item.icon" [color]="item.color"
-					  [allowClose]="true">
-				<div class="alert alert-warning">
-					Este es el contenido de <strong>{{item.label}}</strong>
-				</div>
-			</plex-tab>
-		</plex-tabs>
-	</plex-layout-main>
-	<plex-layout-sidebar>
-		<plex-tabs size="full">
-			<plex-tab icon="account" label="Buscador" color="procedimiento">
-				<div class="alert alert-info">
-					Contenido 1
-				</div>
-			</plex-tab>
-			<plex-tab label="Historia de Salud">
-				<div class="alert alert-warning">
-					Contenido 2
-				</div>
-			</plex-tab>
-			<plex-tab icon="file-tree">
-				<div class="alert alert-danger">
-					Contenido 3
-				</div>
-			</plex-tab>
-		</plex-tabs>
-	</plex-layout-sidebar>
+    <plex-layout-main>
+        <plex-title titulo="plex-tabs | Casos de uso y tipologías">
+            <plex-button (click)="next()" label="Siguiente tab"></plex-button>
+        </plex-title>
+        <pre>Tab activo: {{activo}}</pre>
+        <section justify>
+            <plex-tabs [activeIndex]="activo" (change)="cambio($event)">
+                <plex-tab label="Tab 1" color="procedimiento">
+                    <div class="alert alert-info">
+                        Contenido 1
+                    </div>
+                </plex-tab>
+                <plex-tab *ngIf="mostrar" label="Tab 2" icon="account">
+                    <div class="alert alert-warning">
+                        Contenido 2
+                    </div>
+                </plex-tab>
+                <plex-tab icon="history">
+                    <div class="alert alert-danger" *plTab="5000">
+                        Contenido 3
+                        <span *ngFor="let item of contenidoAsync | async"> {{ item }} </span>
+                    </div>
+                </plex-tab>
+                <plex-button type="info" size="sm" title="anterior" icon="chevron-left" (click)="previous()">
+                </plex-button>
+                <plex-button type="info" size="sm" title="siguiente" icon="chevron-right" (click)="next()">
+                </plex-button>
+            </plex-tabs>
+        </section>
+        <plex-title titulo="Tabs dinámicos">
+            <plex-button (click)="add()" label="Agregar" type="success"></plex-button>
+        </plex-title>
+        <section justify>
+            <plex-tabs [activeIndex]="activoDinamico" (close)="close($event)">
+                <plex-tab *ngFor="let item of tabs" [label]="item.label" [icon]="item.icon" [color]="item.color"
+                          [allowClose]="true">
+                    <div>
+                        Este es el contenido de <strong>{{item.label}}</strong>
+                    </div>
+                    <p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.
+                        Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
+                        mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa
+                        quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo,
+                        rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.
+                        Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend
+                        tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante,
+                        dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet.
+                    </p>
+                </plex-tab>
+                <plex-badge type="warning" size="sm">badge warning</plex-badge>
+                <plex-button type="info" size="sm" label="test"></plex-button>
+                <plex-button type="warning" size="sm" label="test"></plex-button>
+            </plex-tabs>
+        </section>
+    </plex-layout-main>
+    <plex-layout-sidebar type="invert">
+        <plex-tabs size="full">
+            <plex-tab icon="account" label="Inicio">
+                <div class="d-flex flex-column mt-4 justify-content-center align-items-center">
+                    <b>Primer pestaña.</b>Generalmente utilizada como panel de resumen.
+                </div>
+            </plex-tab>
+            <plex-tab icon="pencil" label="Edición" color="procedimiento">
+                <div class="alert alert-danger">
+                    <b>Segunda pestaña.</b>Generalmente utilizado como panel para la edición de datos.
+                </div>
+            </plex-tab>
+            <plex-tab icon="clock" label="Histórico" color="default">
+                <div class="alert alert-info">
+                    <b>Tercera pestaña.</b>Generalmente utilizado como panel para listados de historiales.
+                </div>
+            </plex-tab>
+            <plex-button type="danger" size="sm" icon="close" title="prueba sidebar"></plex-button>
+        </plex-tabs>
+    </plex-layout-sidebar>
 </plex-layout>

--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -22,6 +22,8 @@
                         <span *ngFor="let item of contenidoAsync | async"> {{ item }} </span>
                     </div>
                 </plex-tab>
+                <plex-dropdown label="hola" size="sm" [items]="items" right="false">
+                </plex-dropdown>
                 <plex-button type="info" size="sm" title="anterior" icon="chevron-left" (click)="previous()">
                 </plex-button>
                 <plex-button type="info" size="sm" title="siguiente" icon="chevron-right" (click)="next()">

--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -9,6 +9,7 @@
                 <plex-tab label="Tab 1" color="procedimiento">
                     <div class="alert alert-info">
                         Contenido 1
+                        <span *ngFor="let item of contenidoAsync | async"> {{ item }} </span>
                     </div>
                 </plex-tab>
                 <plex-tab *ngIf="mostrar" label="Tab 2" icon="account">
@@ -19,7 +20,6 @@
                 <plex-tab icon="history">
                     <div class="alert alert-danger" *plTab="5000">
                         Contenido 3
-                        <span *ngFor="let item of contenidoAsync | async"> {{ item }} </span>
                     </div>
                 </plex-tab>
                 <plex-dropdown label="hola" size="sm" [items]="items" right="false">

--- a/src/lib/css/plex-tabs.scss
+++ b/src/lib/css/plex-tabs.scss
@@ -11,7 +11,7 @@ $plex-tabs-color-extend: (
 plex-tabs {
     width: 100%;
     
-    section#tabs {
+    section:first-child {
         display: flex;
         justify-content: space-between;
         align-items: flex-start;
@@ -101,7 +101,7 @@ plex-tabs {
             & + div {
                 width: fit-content;
                 
-                plex-button, plex-badge {
+                plex-button, plex-badge, plex-dropdown {
                     margin-left: .5rem;
                 }
             }

--- a/src/lib/css/plex-tabs.scss
+++ b/src/lib/css/plex-tabs.scss
@@ -2,11 +2,11 @@
 /**
  * Array de colores expandibles de los tabs desde una aplicación externa.
  */
+ 
 $plex-tabs-color-extend: (
   procedimiento: $red,
   trastorno: violet
 ) !default;
-
 
 plex-tabs {
     width: 100%;
@@ -18,12 +18,9 @@ plex-tabs {
         border-bottom: solid 1px black;
     
         .nav-tabs {
-            //--buttonContainer: fit-content;
-
             overflow-x: auto;
             overflow-y: hidden;
             width: 100%;
-            //width: calc(100% - var(--buttonContainer));
             border: none;
             white-space: nowrap;
         
@@ -64,7 +61,6 @@ plex-tabs {
                     font-weight: 600; 
                 }
         
-        
                 &.nav-item-default {
                     background-color: $white;
                     color: $blue;
@@ -84,7 +80,6 @@ plex-tabs {
                         }
                     }
                 }
-        
         
                 .close {
                     margin-left: 1em;

--- a/src/lib/css/plex-tabs.scss
+++ b/src/lib/css/plex-tabs.scss
@@ -7,85 +7,116 @@ $plex-tabs-color-extend: (
   trastorno: violet
 ) !default;
 
-.nav-tabs {
-    overflow-x: auto;
-    overflow-y: hidden;
-    border: none;
-    white-space: nowrap;
 
-    &.full .nav-item {
-        flex: 1;
-        text-align: center;
-        a {
-            width: 100%;
-        }
-    }
-    & .icon {
-        max-width: 50px;
-    }
-
-    .nav-item {
-        margin-bottom: -7px;
-        text-transform: uppercase;
-        opacity: 0.75;
-        border: 1px solid #a5a5a5;
-        border-top-right-radius: 0.25rem;
-        border-top-left-radius: 0.25rem;
+plex-tabs {
+    width: 100%;
     
-        &.active {
-            opacity: 1;
-        }
-        
-        .nav-link {
+    section#tabs {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        border-bottom: solid 1px black;
+    
+        .nav-tabs {
+            //--buttonContainer: fit-content;
+
+            overflow-x: auto;
+            overflow-y: hidden;
+            width: 100%;
+            //width: calc(100% - var(--buttonContainer));
             border: none;
-            span {
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
+            white-space: nowrap;
+        
+            &.full .nav-item {
+                flex: 1;
+                text-align: center;
+                a {
+                    width: 100%;
+                }
             }
-        }
-
-        a.active {
-            border: 0px none $dark-blue;
-            font-weight: 600; 
-        }
-
-
-        &.nav-item-default {
-            background-color: $white;
-            color: $blue;
-            a.active {
-                background-color: $dark-blue;
-                color: white; 
+            & .icon {
+                max-width: 50px;
             }
-        }
-
-        @each $name, $color in $plex-tabs-color-extend {
-            &.nav-item-#{$name} {
-                background-color: $white; 
-                color: $color; 
+        
+            .nav-item {
+                margin-bottom: -7px;
+                text-transform: uppercase;
+                opacity: 0.75;
+                border: 1px solid #a5a5a5;
+                border-top-right-radius: 0.25rem;
+                border-top-left-radius: 0.25rem;
+            
+                &.active {
+                    opacity: 1;
+                }
+                
+                .nav-link {
+                    border: none;
+                    span {
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                    }
+                }
+        
                 a.active {
-                    background-color: $color; 
-                    color: white; 
+                    border: 0px none $dark-blue;
+                    font-weight: 600; 
+                }
+        
+        
+                &.nav-item-default {
+                    background-color: $white;
+                    color: $blue;
+                    a.active {
+                        background-color: $dark-blue;
+                        color: white; 
+                    }
+                }
+        
+                @each $name, $color in $plex-tabs-color-extend {
+                    &.nav-item-#{$name} {
+                        background-color: $white; 
+                        color: $color; 
+                        a.active {
+                            background-color: $color; 
+                            color: white; 
+                        }
+                    }
+                }
+        
+        
+                .close {
+                    margin-left: 1em;
+                    float: none;
+                    line-height: 0.9;
+                    opacity: 1;
+        
+                    i {
+                        font-size: .7em;
+                    }
+        
+                    &:focus,
+                    &:hover {
+                        outline: none;
+                    }
+                }
+            }
+
+            & + div {
+                width: fit-content;
+                
+                plex-button, plex-badge {
+                    margin-left: .5rem;
                 }
             }
         }
+    }
+}
 
-
-        .close {
-            margin-left: 1em;
-            float: none;
-            line-height: 0.9;
-            opacity: 1;
-
-            i {
-                font-size: .7em;
-            }
-
-            &:focus,
-            &:hover {
-                outline: none;
-            }
-        }
+// INVERT
+plex-layout-sidebar[type="invert"] {
+    section#tabs  {
+        border-bottom: solid 1px white;
     }
 }

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -3,18 +3,27 @@ import { PlexTabComponent } from './tab.component';
 
 @Component({
     selector: 'plex-tabs',
-    template: ` <ul #container class="nav nav-tabs" [ngClass]="size">
-                    <li *ngFor="let tab of tabs" (click)="selectTab(tab)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
-                        <a class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
-                            <i *ngIf="tab.icon" class="mdi mdi-{{tab.icon}}"></i>
-                            <span *ngIf="tab.label">
-                                {{ tab.label  }}
-                            </span>
-                            <button *ngIf="tab.allowClose" type="button" class="close" (click)="closeTab(tab)"><i class="mdi mdi-close"></i></button>
-                        </a>
-                    </li>
-                </ul>
-                <ng-content></ng-content>`,
+    template: ` <section id="tabs" justify>
+                    <ul #container class="nav nav-tabs" [ngClass]="size">
+                        <li *ngFor="let tab of tabs" (click)="selectTab(tab)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
+                            <a class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
+                                <i *ngIf="tab.icon" class="mdi mdi-{{tab.icon}}"></i>
+                                <span *ngIf="tab.label">
+                                    {{ tab.label  }}
+                                </span>
+                                <button *ngIf="tab.allowClose" type="button" class="close" (click)="closeTab(tab)"><i class="mdi mdi-close"></i></button>
+                            </a>
+                        </li>
+                    </ul>
+                    <div justify="end">
+                        <ng-content select="plex-badge"></ng-content>
+                        <ng-content select="plex-button"></ng-content>
+                    </div>
+                </section>
+                <section>
+                    <ng-content></ng-content>
+                </section>
+                `,
 })
 export class PlexTabsComponent implements AfterContentInit {
     private _activeIndex = 0;

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -18,6 +18,7 @@ import { PlexTabComponent } from './tab.component';
                     <div justify="end">
                         <ng-content select="plex-badge"></ng-content>
                         <ng-content select="plex-button"></ng-content>
+                        <ng-content select="plex-help"></ng-content>
                     </div>
                 </section>
                 <section>

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -3,7 +3,7 @@ import { PlexTabComponent } from './tab.component';
 
 @Component({
     selector: 'plex-tabs',
-    template: ` <section id="tabs" justify>
+    template: ` <section justify>
                     <ul #container class="nav nav-tabs" [ngClass]="size">
                         <li *ngFor="let tab of tabs" (click)="selectTab(tab)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
                             <a class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
@@ -17,6 +17,7 @@ import { PlexTabComponent } from './tab.component';
                     </ul>
                     <div justify="end">
                         <ng-content select="plex-badge"></ng-content>
+                        <ng-content select="plex-dropdown"></ng-content>
                         <ng-content select="plex-button"></ng-content>
                         <ng-content select="plex-help"></ng-content>
                     </div>


### PR DESCRIPTION
Se permite la posibilidad de incluir tanto plex-badge como plex-button al mismo nivel de los tabs.

![plex-tabs-buttons](https://user-images.githubusercontent.com/5895886/88461880-dd76b680-ce7d-11ea-8709-705bf8c5c84a.PNG)

**Tarea boyscout:** Se invierte color de línea base de tabs para uso invert.

