### PR TITLE
feat(plex-title): permite agregar wrapper y tabs

### DIFF
--- a/src/demo/app/wrapper/wrapper.html
+++ b/src/demo/app/wrapper/wrapper.html
@@ -1,44 +1,67 @@
 <plex-layout main="8">
     <plex-layout-main>
-        <plex-title titulo="plex-wrapper">
-            <plex-button type="success" size="sm">accion satisfactoria</plex-button>
-        </plex-title>
-        <plex-wrapper>
-            <plex-datetime grow="4" label="Ingrese la fecha" [(ngModel)]="tModel.fechaHora" name="fechaHora">
-            </plex-datetime>
-            <plex-int grow="4" label="plex-int" [(ngModel)]="tModel.valor" name="valor" min="10" max="90" suffix="%">
-            </plex-int>
-            <plex-select grow="4" [(ngModel)]="modelo1.select" [data]="opciones"
-                         label="Seleccione efector ojo que tiene nombre largo">
-            </plex-select>
-            <plex-text grow="4" label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre">
-            </plex-text>
-            <plex-float grow="1" label="plex-float" placeholder="Ingrese porcentaje entre 10.5 y 90.4"
-                        [(ngModel)]="tModel.valor" name="valor" [min]="10.5" [max]="90.4" suffix="%"></plex-float>
-            <div collapse>
-                <plex-int label="plex-int" [(ngModel)]="tModel.valor" name="valor" min="10" max="90" suffix="%">
-                </plex-int>
-                <plex-bool [(ngModel)]="modelo.slide" type="slide" label="¿Está activo?" name="slide"></plex-bool>
-                <plex-text label="Buscar profesional" [(ngModel)]="templateModel2.nombre" name="nombre"></plex-text>
-                <plex-select grow="2" [(ngModel)]="modelo1.select" [data]="opciones"
-                             label-field="nombre + ' (' + continente + ')'" label="Seleccione efector">
+        <plex-title main titulo="plex-wrapper sticky!">
+            <plex-wrapper>
+                <plex-datetime label="Ingrese la fecha" [(ngModel)]="tModel.fechaHora" name="fechaHora">
+                </plex-datetime>
+                <plex-select grow="4" [(ngModel)]="modelo1.select" [data]="opciones" label="Seleccione efector">
                 </plex-select>
-                <plex-radio [(ngModel)]="modelo1.radio" [data]="opciones2" name="colores" type="horizontal"
-                            [required]="true">
-                </plex-radio>
-            </div>
-        </plex-wrapper>
-        <plex-title titulo="plex-wrapper sin secundarios">
+                <plex-text label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre"> </plex-text>
+                <!-- <plex-button type="success">BUSCAR</plex-button> -->
+                <plex-dropdown label="OLA" type="success"></plex-dropdown>
+                <div collapse>
+                    <plex-select grow="4" [(ngModel)]="modelo1.select" [data]="opciones"
+                                 label="Seleccione efector ojo que tiene nombre largo">
+                    </plex-select>
+                    <plex-text grow="3" label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre">
+                    </plex-text>
+                    <plex-radio grow="1" [(ngModel)]="modelo1.radio" [data]="opciones2" name="colores" type="horizontal"
+                                [required]="true">
+                    </plex-radio>
+                </div>
+            </plex-wrapper>
         </plex-title>
-        <plex-wrapper>
-            <plex-datetime label="Ingrese la fecha" [(ngModel)]="tModel.fechaHora" name="fechaHora">
-            </plex-datetime>
-            <plex-select grow="4" [(ngModel)]="modelo1.select" [data]="opciones" label="Seleccione efector">
-            </plex-select>
-            <plex-text label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre"> </plex-text>
-            <!-- <plex-button type="success">BUSCAR</plex-button> -->
-            <plex-dropdown label="OLA" type="success"></plex-dropdown>
-        </plex-wrapper>
+        <plex-list>
+            <plex-heading>
+                <b label>Titulo</b>
+                <b label>Subtitulo</b>
+            </plex-heading>
+            <plex-item>
+                <plex-icon name="star" type="info"></plex-icon>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-badge size="sm" type="warning">este es un badge</plex-badge>
+                <plex-button size="sm" type="info">button</plex-button>
+            </plex-item>
+            <plex-item>
+                <plex-icon name="star" type="info"></plex-icon>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-badge size="sm" type="warning">este es un badge</plex-badge>
+                <plex-button size="sm" type="info">button</plex-button>
+            </plex-item>
+            <plex-item>
+                <plex-icon name="star" type="info"></plex-icon>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-badge size="sm" type="warning">este es un badge</plex-badge>
+                <plex-button size="sm" type="info">button</plex-button>
+            </plex-item>
+            <plex-item>
+                <plex-icon name="star" type="info"></plex-icon>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-badge size="sm" type="warning">este es un badge</plex-badge>
+                <plex-button size="sm" type="info">button</plex-button>
+            </plex-item>
+            <plex-item>
+                <plex-icon name="star" type="info"></plex-icon>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-label titulo="Titulo de item" subtitulo="Subtitulo del item"></plex-label>
+                <plex-badge size="sm" type="warning">este es un badge</plex-badge>
+                <plex-button size="sm" type="info">button</plex-button>
+            </plex-item>
+        </plex-list>
         <plex-title titulo="plex-wrapper otros ejemplos">
         </plex-title>
         <plex-wrapper>
@@ -47,34 +70,46 @@
             <plex-text label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre"> </plex-text>
             <plex-text label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre"> </plex-text>
         </plex-wrapper>
-        <plex-list>
-            <plex-item></plex-item>
-            <plex-item></plex-item>
-            <plex-item></plex-item>
-            <plex-item></plex-item>
-            <plex-item></plex-item>
-            <plex-item></plex-item>
-            <plex-item></plex-item>
-            <plex-item></plex-item>
-        </plex-list>
     </plex-layout-main>
     <plex-layout-sidebar type="invert">
+
         <plex-title titulo="Casos de uso: Formulario"></plex-title>
+        <plex-title size="sm" titulo="plex-wrapper desplegable (collapse)">
+            <plex-button type="success" size="sm">accion</plex-button>
+        </plex-title>
+        <plex-wrapper>
+            <plex-datetime grow="4" label="Ingrese la fecha" [(ngModel)]="tModel.fechaHora" name="fechaHora">
+            </plex-datetime>
+            <plex-int grow="4" label="plex-int" [(ngModel)]="tModel.valor" name="valor" min="10" max="90" suffix="%">
+            </plex-int>
+            <div collapse>
+                <plex-select grow="4" [(ngModel)]="modelo1.select" [data]="opciones"
+                             label="Seleccione efector ojo que tiene nombre largo">
+                </plex-select>
+                <plex-text grow="3" label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre">
+                </plex-text>
+                <plex-radio grow="1" [(ngModel)]="modelo1.radio" [data]="opciones2" name="colores" type="horizontal"
+                            [required]="true">
+                </plex-radio>
+            </div>
+        </plex-wrapper>
+        <hr class="mt-4 mb-4">
+        <plex-title size="sm" titulo="plex-wrapper no desplegable">
+            <plex-button type="info" size="sm">accion</plex-button>
+        </plex-title>
         <plex-wrapper>
             <plex-datetime label="Ingrese la fecha" [(ngModel)]="tModel.fechaHora" name="fechaHora" required>
             </plex-datetime>
             <plex-select grow="2" [(ngModel)]="modelo1.select" [data]="opciones" label="Seleccione efector">
             </plex-select>
             <plex-text label="Buscar paciente" [(ngModel)]="templateModel2.nombre" name="nombre"></plex-text>
-            <div collapse>
-                <plex-float label="plex-float" placeholder="Ingrese porcentaje entre 10.5 y 90.4"
-                            [(ngModel)]="tModel.valor" name="valor" [min]="10.5" [max]="90.4" suffix="%"></plex-float>
-                <plex-bool [(ngModel)]="modelo.slide" type="slide" label="¿Está activo?" name="slide"></plex-bool>
-                <plex-text label="Buscar profesional" [(ngModel)]="templateModel2.nombre" name="nombre"></plex-text>
-                <plex-select grow="auto" [(ngModel)]="modelo1.select" [data]="opciones"
-                             label-field="nombre + ' (' + continente + ')'" label="Seleccione efector">
-                </plex-select>
-            </div>
+            <plex-float label="plex-float" placeholder="Ingrese porcentaje entre 10.5 y 90.4" [(ngModel)]="tModel.valor"
+                        name="valor" [min]="10.5" [max]="90.4" suffix="%"></plex-float>
+            <plex-bool [(ngModel)]="modelo.slide" type="slide" label="¿Está activo?" name="slide"></plex-bool>
+            <plex-text label="Buscar profesional" [(ngModel)]="templateModel2.nombre" name="nombre"></plex-text>
+            <plex-select grow="auto" [(ngModel)]="modelo1.select" [data]="opciones"
+                         label-field="nombre + ' (' + continente + ')'" label="Seleccione efector">
+            </plex-select>
         </plex-wrapper>
         <section justify="between">
             <plex-button type="danger" size="md">Cancelar</plex-button>

--- a/src/lib/css/plex-wrapper.scss
+++ b/src/lib/css/plex-wrapper.scss
@@ -69,7 +69,7 @@ plex-wrapper  {
         }
     }
 
-    // Alinear elementos en formulario
+    // Alinea elementos en formulario
     plex-bool {
         display: flex;
         align-items: center;

--- a/src/lib/title/title.component.ts
+++ b/src/lib/title/title.component.ts
@@ -9,6 +9,10 @@ import { Component, Input, Renderer } from '@angular/core';
                 <ng-content></ng-content>
             </div>
         </div>
+        <div>
+            <ng-content select="plex-tabs"></ng-content>
+            <ng-content select="plex-wrapper"></ng-content>
+        </div>
     `
 })
 export class PlexTitleComponent {


### PR DESCRIPTION
Se agregan dos selectores dentro del plex-title para permitir convivencia ordenada con plex-wrapper y plex-tabs.

![sticky](https://user-images.githubusercontent.com/5895886/88714975-f1c3e900-d0f3-11ea-90f4-88cf28f2a9b1.gif)
