### PR TITLE
fix(plex-item): expande contenedor badge para evitar apilamiento

### DIFF
--- a/src/demo/app/item-list/item-list.html
+++ b/src/demo/app/item-list/item-list.html
@@ -165,20 +165,20 @@
                 </plex-select>
                 <plex-dropdown icon="dots-vertical mdi-24px" [right]="true" [items]="dropitems">
                 </plex-dropdown>
-                <plex-button type="warning" size="sm" icon="clock"></plex-button>
-                <plex-button type="danger" size="sm" label="Eliminar" (click)="tModelFecha.fechaHora = null">
-                </plex-button>
                 <plex-datetime [(ngModel)]="tModelFecha.fechaHora" type="time" name="fechaHora" skipBy="hour"
                                showNav="true">
                 </plex-datetime>
-                <plex-badge type="danger">urgente</plex-badge>
-                <plex-button type="success" size="sm" label="Aprobar"></plex-button>
+                <plex-badge type="info">iconografico</plex-badge>
+                <plex-button type="warning" size="sm" icon="clock"></plex-button>
+                <plex-button type="danger" size="sm" icon="delete" (click)="tModelFecha.fechaHora = null">
+                </plex-button>
+                <plex-button type="success" size="sm" icon="check"></plex-button>
             </plex-item>
         </plex-list>
         <hr>
         <plex-list>
             <plex-heading>
-                <b label>Datos importantes con plex-bool</b>
+                <b label>Datos con plex-bool</b>
                 <b label>Horario</b>
             </plex-heading>
             <plex-item>
@@ -195,13 +195,11 @@
         </plex-list>
         <plex-list>
             <plex-heading>
-                <b label>Datos importantes sin plex-bool</b>
-                <b label>Horario</b>
+                <b label>Datos sin plex-bool</b>
             </plex-heading>
             <plex-item>
                 <plex-label titulo="Título" subtitulo="Un subtítulo"></plex-label>
-                <plex-dropdown label="Dropdown con título" [items]="dropitems">
-                </plex-dropdown>
+                <plex-badge type="info">Este es un badge más largo</plex-badge>
                 <plex-badge type="success">aprobado</plex-badge>
                 <plex-badge type="danger">urgente</plex-badge>
                 <plex-button type="success" size="sm" label="Aprobar"></plex-button>

--- a/src/lib/css/plex-item.scss
+++ b/src/lib/css/plex-item.scss
@@ -94,7 +94,7 @@ plex-list {
         
         .item-row {
             @include flex;
-            width: 75%;
+            width: 70%;
             
             .elementos-graficos {
                 @include flex;
@@ -189,7 +189,8 @@ plex-list {
     
     div.botonera {
         display: flex;
-        width: 25%;
+        min-width: 30%;
+        width: fit-content;
         justify-content: flex-end;
         text-align: right;
 
@@ -199,31 +200,42 @@ plex-list {
         upload-file {
             margin: .25rem 0 .25rem .25rem;
         }
+
+        & > div {
+            display: flex;
+            flex-direction: row;
+    
+            &:first-child {
+                margin-bottom: 2px;
+            }
+    
+            plex-dropdown {
+                display: flex;
+                align-items: center;
+        
+                .btn,
+                .dropdown-item {
+                    padding: 5px;
+                    font-size: .9rem;
+                    background: transparent !important;
+                }
+        
+                &[icon] {
+                    button {
+                        padding: 0;
+                        border: 0;
+                        height: 27px;
+                    }
+        
+                    i {
+                        line-height: 28px;
+                    }
+                }
+            }
+    
+        }
     }
 
-    plex-dropdown {
-        display: flex;
-        align-items: center;
-
-        .btn,
-        .dropdown-item {
-            padding: 5px;
-            font-size: .9rem;
-            background: transparent !important;
-        }
-
-        &[icon] {
-            button {
-                padding: 0;
-                border: 0;
-                height: 27px;
-            }
-
-            i {
-                line-height: 28px;
-            }
-        }
-    }
 }
 
     // Grilla interna
@@ -238,7 +250,7 @@ plex-list {
     }
     
     .item-list-heading {
-        width: 75%;
+        width: 70%;
     }
     
     // Sin checkbox, Sin icono
@@ -263,7 +275,7 @@ plex-list {
 
     // Directiva responsive
     plex-list {
-        > div.size-sm {
+        > div.size-sm, div.size-md {
             
             section {
                 .item-list-heading {
@@ -282,7 +294,6 @@ plex-list {
                 div.item-list {
                     margin-top: .5rem;
                     grid-auto-flow: unset;
-                    // width: 100%!important;
                 }
         
                 .botonera {

--- a/src/lib/item-list/item.component.ts
+++ b/src/lib/item-list/item.component.ts
@@ -26,10 +26,12 @@ import { PlexButtonComponent } from '../button/button.component';
             <div class="botonera">
                 <div>
                     <ng-content select="plex-badge"></ng-content>
+                </div>
+                <div>
                     <ng-content select="plex-button"></ng-content>
                     <ng-content select="upload-file"></ng-content>
+                    <ng-content select="plex-dropdown[icon]"></ng-content>
                 </div>
-                <ng-content select="plex-dropdown[icon]"></ng-content>
             </div>
         </section>
     `


### PR DESCRIPTION
Con el objetivo de evitar apilamiento de elementos badge y buttons se realizan las siguientes modificaciones al contenedor de dichos elementos:

- Se establece el valor 'row' en la propiedad flex-direction
- Se aumenta el porcentaje del ancho (width) del contenedor
- Se define en 'fit-content' el max-width para mayor aprovechamiento del espacio (casos de poca info en el item)

![expande-badge](https://user-images.githubusercontent.com/5895886/90050368-785bf700-dcac-11ea-91cc-9d6affffbebc.PNG)

**Plus:**
- El comportamiento responsive ahora comienza a funcionar en el breakpoint 'md' (.size-md)
- Se marginan los botones a la derecha en visualización responsive para evitar 'efecto bandera'

![Mejoracomparativa-item](https://user-images.githubusercontent.com/5895886/90050420-8b6ec700-dcac-11ea-9127-c9bcb4c8021d.jpg)
