### PR TITLE
fix(hint): change detection para evitar error al iniciar + click vacío

### DIFF
--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, Input, ChangeDetectorRef, HostListener } from '@angular/core';
+import { Component, OnInit, Input, HostListener } from '@angular/core';
 import { PlexType } from '../core/plex-type.type';
 
 @Component({
@@ -9,7 +9,7 @@ import { PlexType } from '../core/plex-type.type';
         </a>
     `
 })
-export class HintComponent implements OnInit, AfterViewInit {
+export class HintComponent implements OnInit {
 
     @Input()
     hostElement: HTMLElement;
@@ -26,15 +26,10 @@ export class HintComponent implements OnInit, AfterViewInit {
     @Input()
     position = 'above';
 
-    constructor(
-        private cdr: ChangeDetectorRef) { }
+    constructor() { }
 
     ngOnInit() {
         this.position = 'above';
-    }
-
-    ngAfterViewInit(): void {
-        this.cdr.detectChanges();
     }
 
     // Si el elemento que tiene la directiva [hint] tiene un evento (click), este se ejecutará, guste o no.

--- a/src/lib/hint/hint.directive.ts
+++ b/src/lib/hint/hint.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ComponentRef, ViewContainerRef, ComponentFactoryResolver, Input, AfterViewInit } from '@angular/core';
+import { Directive, ComponentRef, ViewContainerRef, ComponentFactoryResolver, Input, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { HintComponent } from './hint.component';
 import { PlexType } from '../core/plex-type.type';
 
@@ -25,11 +25,13 @@ export class HintDirective implements AfterViewInit {
 
     constructor(
         private viewContainerRef: ViewContainerRef,
-        private resolver: ComponentFactoryResolver
+        private resolver: ComponentFactoryResolver,
+        private cdr: ChangeDetectorRef
     ) {
     }
 
     ngAfterViewInit(): void {
+        this.cdr.detectChanges();
 
         const factory = this.resolver.resolveComponentFactory(HintComponent);
         this.tooltip = this.viewContainerRef.createComponent(factory);


### PR DESCRIPTION
2 fixes
- ExpressionChangedAfterItHasBeenCheckedError al iniciar una página que contiene un hint
- Se quita uso de $event, ya que no existe cuando el hint no tiene ningún $event...