### PR TITLE
feat(plex-detail): agrega plex-grid interno

### DIFF
--- a/src/demo/app/detail/detail.html
+++ b/src/demo/app/detail/detail.html
@@ -1,7 +1,7 @@
 <plex-layout main="8">
     <plex-layout-main>
         <plex-title titulo="Titulo principal">
-            <plex-help type="info">
+            <plex-help type="info" cardSize="half">
                 <div info justify="center">
                     <plex-detail direction="column" justify="center">
                         <img src="{{ paciente.foto }}" alt="">

--- a/src/lib/css/layout.scss
+++ b/src/lib/css/layout.scss
@@ -61,7 +61,7 @@ plex-layout {
       }
 
     //  Calle izq. del sidebar en responsive
-      > div > div:nth-child(2) {
+      > div > div.focused:nth-child(2) {
         padding-left: 10px;
       } 
   }

--- a/src/lib/css/plex-detail.scss
+++ b/src/lib/css/plex-detail.scss
@@ -8,6 +8,19 @@ plex-detail {
     // md size = md default
     --detail-img-size: 4.5rem;
 
+    &[direction="column"] {
+        flex-direction: column;
+
+        plex-label {
+            display: flex;
+            justify-content: center;
+        }
+    }
+    
+    &[direction="row"] {
+        flex-direction: row;
+    }
+
     &[size=lg] {
         --detail-img-size: 5.5rem;
     }
@@ -16,23 +29,29 @@ plex-detail {
         --detail-img-size: 3.5rem;
     }
      
-    section.direction-column {
-        --detail-divider-align: center;
-        --detail-img-mr: 0;
-        --detail-img-mb: 1rem;
-        --detail-text-align: center;
-        --detail-badge-align: center;
+    section, plex-grid {
+        &.direction-column {
+            --detail-divider-align: center;
+            --detail-img-mr: 0;
+            --detail-img-mb: 1rem;
+            --detail-text-align: center;
+            --detail-badge-align: center;
+            width: 100%;
+            text-align: center;
+        }
     }
     
-    section.direction-row {
-        --detail-divider-align: start; 
-        --detail-img-mr: 0.75rem;
-        --detail-img-mb: 1rem;
-        --detail-text-align: left;
-        
-        .contenedor-textos {
-            width: fit-content;
-            margin-right: 2rem;
+    section, plex-grid {
+        &.direction-row {
+            --detail-divider-align: start; 
+            --detail-img-mr: 0.75rem;
+            --detail-img-mb: 1rem;
+            --detail-text-align: left;
+            
+            .contenedor-textos {
+                width: fit-content;
+                margin-right: 2rem;
+            }
         }
     }
 
@@ -46,6 +65,7 @@ plex-detail {
         flex-direction: column;
         justify-content: center;
         text-align: center;
+        align-self: center;
 
         span {
             justify-content: var(--detail-badge-align);
@@ -116,7 +136,6 @@ plex-detail {
         }
     }
         
-
     // size-lg
     section.size-lg {
 
@@ -164,8 +183,8 @@ plex-detail {
         }
     }
 
-        // size-xs
-    section.size-md { 
+    // size-sm
+    section.size-sm { 
         div.contenedor-elementos-graficos { 
             // se disminuyen las imagenes
             img {  
@@ -189,20 +208,6 @@ plex-detail {
             div[subtitle] {
                 font-size: 0.75rem;
             }
-        }
-    }
-
-    .contenedor-datos-secundarios {
-        display: grid;
-        grid-template-columns: repeat( auto-fill, minmax(100px, 1fr));
-        grid-gap: 10px; 
-        flex: 1 20em;
-        align-self: center;
-        text-transform: capitalize;
-        text-align: var(--detail-text-align);
-
-        span {
-            white-space: wrap;
         }
     }
 }

--- a/src/lib/detail/detail.component.ts
+++ b/src/lib/detail/detail.component.ts
@@ -18,13 +18,12 @@ import { PlexLabelComponent } from '../label/label.component';
                 <hr>
             </div>
         </section>
-
-        <section [ngClass]="cssDirection" class="contenedor-datos-secundarios">
+        <plex-grid size="md" type="auto" [ngClass]="cssDirection">
             <ng-container *ngFor="let dato of items">
                 <plex-label titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"></plex-label>
             </ng-container>
             <ng-content select="plex-label"></ng-content>
-        </section>
+        </plex-grid>
     `,
 })
 


### PR DESCRIPTION
- Se agrega plex-grid para distribuir los datos secundarios (plex-labels) del componente
- Ajustes de alineamiento de textos
- Se corrige el ancho del contenedor del dato principal en disposición 'column' para evitar efecto indeseado (ver adjunto)

![fix-detail](https://user-images.githubusercontent.com/5895886/93761054-84a86d80-fbe3-11ea-95a5-6bf16cc47f46.gif)
