### PR TITLE
feat(aligned): crea directiva

### DIFF
--- a/src/lib/directives/aligned.directive.ts
+++ b/src/lib/directives/aligned.directive.ts
@@ -1,0 +1,23 @@
+import { Directive, Input, HostBinding } from '@angular/core';
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[aligned]'
+})
+export class AlignedDirective {
+    @Input() aligned: 'start' | 'end' | 'center' = 'center';
+
+    @HostBinding('class.d-flex') flex = true;
+
+    @HostBinding('class.align-items-start') get start() {
+        return this.aligned === 'start';
+    }
+
+    @HostBinding('class.align-items-end') get end() {
+        return this.aligned === 'end';
+    }
+
+    @HostBinding('class.align-items-center') get center() {
+        return !this.aligned || this.aligned === 'center';
+    }
+}

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -51,6 +51,7 @@ import { PlexGridComponent } from './grid/grid.component';
 import { PlexCardComponent } from './card/card.component';
 
 // Directivas
+import { AlignedDirective } from './directives/aligned.directive';
 import { PlexWizardDirective } from './wizard/wizard.directive';
 import { GrowDirective } from './directives/grow.directive';
 import { JustifyDirective } from './directives/justify.directive';
@@ -137,6 +138,7 @@ import { NetworkLoadingInterceptor, NETWORK_LOADING } from './core/network-loadi
         PlexCardComponent,
 
         // Directivas
+        AlignedDirective,
         GrowDirective,
         HelpDirective,
         HintDirective,
@@ -208,6 +210,7 @@ import { NetworkLoadingInterceptor, NETWORK_LOADING } from './core/network-loadi
         PlexCardComponent,
 
         // Directivas
+        AlignedDirective,
         GrowDirective,
         HelpDirective,
         HintDirective,


### PR DESCRIPTION
- Es una directiva que permite alinear los elementos en el eje vertical de un determinado espacio.
- Es el equivalente a 'align-items' de flex y sus respectivos valores (center, start y end), tomando por defecto 'center'.
- Evita que el desarrollador deba escribir un conjunto de clases sintetizándolas en un selector [aligned].
- Se emplea aplicando la directiva al tag que envuelve uno o varios elementos hijos.