### PR TITLE
feat(plex-wrapper): notifica filtros activos ocultos

### DIFF
--- a/src/lib/css/plex-wrapper.scss
+++ b/src/lib/css/plex-wrapper.scss
@@ -28,10 +28,14 @@ plex-wrapper  {
         }
     }
 
-    plex-button.btn-toggle {
+    .btn-toggle {
         position: absolute;
         top: 0;
         right: 0;
+
+        > span {
+            position: absolute;
+        }
     }
 
     label {

--- a/src/lib/css/plex-wrapper.scss
+++ b/src/lib/css/plex-wrapper.scss
@@ -36,6 +36,16 @@ plex-wrapper  {
         > span {
             position: absolute;
         }
+        
+        @keyframes blink {
+            50% {opacity: 0;}
+            100% {opacity: 1;}
+            50% {opacity: 0;}
+        }
+
+        plex-hint {
+            animation: blink ease-in 2s;
+        }
     }
 
     label {

--- a/src/lib/css/plex-wrapper.scss
+++ b/src/lib/css/plex-wrapper.scss
@@ -44,7 +44,7 @@ plex-wrapper  {
         }
 
         plex-hint {
-            animation: blink ease-in 2s;
+            animation: blink 2 ease-in 1.5s;
         }
     }
 

--- a/src/lib/wrapper/wrapper.component.ts
+++ b/src/lib/wrapper/wrapper.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit, Input, HostListener, Output, EventEmitter, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
-import { Plex } from '../core/service';
+import { Component, Output, EventEmitter, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 
 @Component({
     selector: 'plex-wrapper',
@@ -10,7 +9,9 @@ import { Plex } from '../core/service';
                 <span *ngIf="filled" detach="top" hint="Hay filtros activos" hintType="warning" hintIcon="plus"></span>
             </div>
         <ng-content></ng-content>
-        <ng-content select="[collapse]"></ng-content>
+        <div (mouseover)="hasFilled()">
+            <ng-content select="[collapse]"></ng-content>
+        </div>
     </section>
 `,
 })
@@ -26,11 +27,9 @@ export class PlexWrapperComponent implements AfterViewInit {
     constructor(
         private elRef: ElementRef,
         private ref: ChangeDetectorRef,
-
     ) {
 
     }
-
 
     ngAfterViewInit() {
         this.hasCollapse = !!this.elRef.nativeElement.querySelector('section [collapse]');
@@ -41,14 +40,8 @@ export class PlexWrapperComponent implements AfterViewInit {
         this.filled = !!this.elRef.nativeElement.querySelector('section [collapse] div.full');
     }
 
-    ngOnInit() {
-        document.onload;
-        this.hasFilled();
-    }
-
     toggle() {
         this.desplegado = !this.desplegado;
         this.change.emit(this.desplegado);
-        this.hasFilled();
     }
 }

--- a/src/lib/wrapper/wrapper.component.ts
+++ b/src/lib/wrapper/wrapper.component.ts
@@ -5,9 +5,10 @@ import { Plex } from '../core/service';
     selector: 'plex-wrapper',
     template: `
     <section class="hidden" [class.desplegado]="desplegado" responsive>
-        <plex-button class="btn-toggle" type="info" size="sm" *ngIf="hasCollapse"
-            [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toggle()">
-        </plex-button>
+            <div class="btn-toggle">
+                <plex-button type="info" size="sm" *ngIf="hasCollapse" [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toggle()"></plex-button>
+                <span *ngIf="filled" detach="top" hint="Hay filtros activos" hintType="warning" hintIcon="plus"></span>
+            </div>
         <ng-content></ng-content>
         <ng-content select="[collapse]"></ng-content>
     </section>
@@ -16,26 +17,38 @@ import { Plex } from '../core/service';
 
 export class PlexWrapperComponent implements AfterViewInit {
 
-    @Output() change = new EventEmitter<Boolean>();
+    @Output() change = new EventEmitter<boolean>();
 
     desplegado = false;
-
     hasCollapse = false;
+    filled = false;
 
     constructor(
         private elRef: ElementRef,
-        private ref: ChangeDetectorRef
+        private ref: ChangeDetectorRef,
+
     ) {
 
     }
+
 
     ngAfterViewInit() {
         this.hasCollapse = !!this.elRef.nativeElement.querySelector('section [collapse]');
         this.ref.detectChanges();
     }
 
+    hasFilled() {
+        this.filled = !!this.elRef.nativeElement.querySelector('section [collapse] div.full');
+    }
+
+    ngOnInit() {
+        document.onload;
+        this.hasFilled();
+    }
+
     toggle() {
         this.desplegado = !this.desplegado;
         this.change.emit(this.desplegado);
+        this.hasFilled();
     }
 }

--- a/src/lib/wrapper/wrapper.component.ts
+++ b/src/lib/wrapper/wrapper.component.ts
@@ -1,17 +1,15 @@
-import { Component, Output, EventEmitter, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, Output, Input, EventEmitter, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 
 @Component({
     selector: 'plex-wrapper',
     template: `
     <section class="hidden" [class.desplegado]="desplegado" responsive>
-            <div class="btn-toggle">
-                <plex-button type="info" size="sm" *ngIf="hasCollapse" [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toggle()"></plex-button>
-                <span *ngIf="filled" detach="top" hint="Hay filtros activos" hintType="warning" hintIcon="plus"></span>
-            </div>
-        <ng-content></ng-content>
-        <div (mouseover)="hasFilled()">
-            <ng-content select="[collapse]"></ng-content>
+        <div class="btn-toggle">
+            <plex-button type="info" size="sm" *ngIf="hasCollapse" [icon]="!desplegado ? 'chevron-down' : 'chevron-up'" (click)="toggle()"></plex-button>
+            <span *ngIf="activeFilters && !desplegado" detach="top" hint="Hay filtros activos" hintType="warning" hintIcon="plus"></span>
         </div>
+        <ng-content></ng-content>
+        <ng-content select="[collapse]"></ng-content>
     </section>
 `,
 })
@@ -19,14 +17,14 @@ import { Component, Output, EventEmitter, ElementRef, AfterViewInit, ChangeDetec
 export class PlexWrapperComponent implements AfterViewInit {
 
     @Output() change = new EventEmitter<boolean>();
+    @Input() activeFilters;
 
     desplegado = false;
     hasCollapse = false;
-    filled = false;
 
     constructor(
         private elRef: ElementRef,
-        private ref: ChangeDetectorRef,
+        private ref: ChangeDetectorRef
     ) {
 
     }
@@ -34,10 +32,6 @@ export class PlexWrapperComponent implements AfterViewInit {
     ngAfterViewInit() {
         this.hasCollapse = !!this.elRef.nativeElement.querySelector('section [collapse]');
         this.ref.detectChanges();
-    }
-
-    hasFilled() {
-        this.filled = !!this.elRef.nativeElement.querySelector('section [collapse] div.full');
     }
 
     toggle() {


### PR DESCRIPTION
Dotar al componente de la capacidad de detectar y notificar cuando un filtro oculto está activo.

- Se agrega el @Input 'activeFilters' que en valor 'true' (y al estar replegado el plex-wrapper) posibilita la visualización de la alerta (plex-hint).

![wrapper-hint](https://user-images.githubusercontent.com/5895886/97454933-0fccff80-1916-11eb-971e-5f63346e3c19.gif)
