### PR TITLE
feat(plex-label): permite caracteres en lugar de icono

### DIFF
--- a/cypress/integration/label.js
+++ b/cypress/integration/label.js
@@ -14,11 +14,9 @@ context('label', () => {
 
         cy.get('small:first');
 
-        cy.get('plex-layout-sidebar plex-title:nth(2)');
+        cy.get('plex-layout plex-title:nth(2)').should('contain.text', 'Cronología');
 
-        cy.get('plex-label:nth(1) plex-icon + div > span').should('contain.text', 'documento');
-
-        cy.get('small:nth(1)').should('contain.text', '29.879.253');
+        cy.get('p[dato]:nth(3)').should('contain.text', '27/11/2020');
 
         cy.eyesCheckWindow('plex-label');
 

--- a/src/demo/app/label/label.component.ts
+++ b/src/demo/app/label/label.component.ts
@@ -9,7 +9,6 @@ export class LabelDemoComponent {
     foto = true;
     icon = false;
 
-
     icono = {
         caracter: 'pencil',
         color: 'info',
@@ -23,6 +22,21 @@ export class LabelDemoComponent {
         { label: 'fecha de nacimiento', valor: '14 de Julio de 1953', type: 'success' },
         { label: 'CUIL', valor: '20-16879253-5', type: 'warning' },
         { label: 'Nota', valor: 'Donec quam felis, ultricies nec, pellentesque eu, pretium quis. Lorem ipsum sonnet.', type: 'warning' },
-        { label: 'Comience buscando un paciente en la barra superior', valor: 'Ingrese al menos tres caracteres. Si la búsqueda no arroja el resultado esperado, presione el botón "Paciente Nuevo"', type: 'warning' }
+        { label: 'Comience buscando un paciente en la barra superior', valor: 'Ingrese al menos tres caracteres. Si la búsqueda no arroja el resultado esperado, presione el botón "Paciente Nuevo"', type: 'warning' },
+    ];
+
+    pasos = [
+        { label: 'A', valor: 'Ingrese al menos tres caracteres. Si la búsqueda no arroja el resultado esperado, presione el botón "Paciente Nuevo".', type: 'Busque un paciente' },
+        { label: 'B', valor: 'La selección se realiza desde los campos desplegables que se encuentran sobre el calendario de agendas.', type: 'Seleccione prestación' },
+        { label: 'C', valor: 'Una vez seleccionado el profesional y la prestación, podrá visualizar las opciones de bloques y horarios.', type: 'Confirme horario' },
+    ];
+
+    eventos = [
+        { label: '27/11/2020', valor: 'Texto descriptivo de un item perteneciente a una línea de tiempo en el que se desarrollan varios eventos.', type: 'Asignada por Alberto Carranza' },
+        { label: '12/10/2020', valor: 'Texto descriptivo de un item perteneciente a una línea de tiempo en el que se desarrollan varios eventos.', type: 'Asignada por Alberto Carranza' },
+        { label: '09/07/2020', valor: 'Texto descriptivo de un item perteneciente a una línea de tiempo en el que se desarrollan varios eventos.', type: 'Asignada por Alberto Carranza' },
+        { label: '21/05/2020', valor: 'Texto descriptivo de un item perteneciente a una línea de tiempo en el que se desarrollan varios eventos.', type: 'Asignada por Alberto Carranza' },
+        { label: '21/12/2019', valor: 'Texto descriptivo de un item perteneciente a una línea de tiempo en el que se desarrollan varios eventos.', type: 'Asignada por Alberto Carranza' },
+        { label: '17/06/2019', valor: 'Texto descriptivo de un item perteneciente a una línea de tiempo en el que se desarrollan varios eventos.', type: 'Asignada por Alberto Carranza' },
     ];
 }

--- a/src/demo/app/label/label.html
+++ b/src/demo/app/label/label.html
@@ -1,60 +1,78 @@
-<plex-layout main=6>
-
-        <plex-layout-main>
-                <plex-title titulo="Usos y atributos"></plex-title>
-                <div class="w-100 h-100 d-flex justify-content-center align-items-center"
-                     *ngFor="let dato of datos | slice:7">
-                        <plex-label icon="arrow-up" type="default" size="xl" direction="column"
-                                    titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"></plex-label>
+<plex-layout main="8">
+    <plex-layout-main>
+        <plex-grid cols="3">
+            <section span="2">
+                <plex-title titulo="Texto descriptivo"></plex-title>
+                <div class="h-50 d-flex justify-content-center align-items-center"
+                     *ngFor="let dato of datos | slice:7:8">
+                    <plex-label icon="arrow-up" type="default" size="xl" direction="column" titulo="{{ dato.label }}"
+                                subtitulo="{{ dato.valor }}"></plex-label>
                 </div>
-        </plex-layout-main>
+                <plex-title titulo="Pasos explicativos" size="sm"></plex-title>
+                <div justify="center" class="h-50">
+                    <plex-label *ngFor="let nodo of pasos" type="info" size="lg" direction="column"
+                                titulo="{{ nodo.type }}" subtitulo="{{ nodo.valor }}">
+                        <p dato>{{ nodo.label }}</p>
+                    </plex-label>
+                </div>
+            </section>
+            <section class="ml-4 d-flex flex-column justify-content-betweeen h-100">
+                <plex-title titulo="Cronología"></plex-title>
+                <plex-label *ngFor="let fecha of eventos" type="info" size="md" direction="row"
+                            titulo="{{ fecha.type }}" subtitulo="{{ fecha.valor }}">
+                    <p dato>{{ fecha.label }}</p>
+                </plex-label>
+            </section>
+        </plex-grid>
+    </plex-layout-main>
 
-
-        <plex-layout-sidebar type="invert">
-                <plex-title titulo="Usos y atributos"></plex-title>
-                <plex-title titulo="Size='xl' | direction='column'" size="sm"></plex-title>
-                <section class="plex-grid">
-                        <div *ngFor="let dato of datos | slice:1:5">
-                                <plex-label type="{{ dato.type }}" direction="column" icon="account" size="xl"
-                                            titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
-                                </plex-label>
-                        </div>
-                        <div>
-                                <plex-label type="success" direction="column" size="xl" titulo="Prueba icono"
-                                            subtitulo="Desacoplado">
-                                        <plex-icon type="success" name="account"></plex-icon>
-                                </plex-label>
-                        </div>
-                        <div>
-                                <plex-label type="success" direction="column" size="xl">
-                                        <plex-icon type="success" name="account"></plex-icon>
-                                        Titulo aparte
-                                </plex-label>
-                        </div>
-                </section>
-                <plex-title titulo="Size='lg' | direction='column'" size="sm"></plex-title>
-                <section class="plex-grid">
-                        <div *ngFor="let dato of datos | slice:1:5">
-                                <plex-label size="lg" direction="column" titulo="{{ dato.label }}"
-                                            subtitulo="{{ dato.valor }}">
-                                </plex-label>
-                        </div>
-                </section>
-                <plex-title titulo="Size='md'(default) | direction='row(default)'" size="sm"></plex-title>
-                <section class="plex-grid">
-                        <div *ngFor="let dato of datos | slice:0:4">
-                                <plex-label size="md" titulo="{{ dato.label }}" icon="star"
-                                            subtitulo="{{ dato.valor }}">
-                                </plex-label>
-                        </div>
-                </section>
-                <plex-title titulo="Size='sm' | direction='row(default)'" size="sm"></plex-title>
-                <section class="plex-grid">
-                        <div *ngFor="let dato of datos">
-                                <plex-label size="sm" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
-                                </plex-label>
-                        </div>
-                </section>
-        </plex-layout-sidebar>
+    <plex-layout-sidebar type="invert">
+        <plex-title titulo="Atributos"></plex-title>
+        <plex-title titulo="Size='xl' | direction='column'" size="sm"></plex-title>
+        <section class="plex-grid">
+            <div *ngFor="let dato of datos | slice:1:5">
+                <plex-label type="{{ dato.type }}" direction="column" icon="account" size="xl" titulo="{{ dato.label }}"
+                            subtitulo="{{ dato.valor }}">
+                </plex-label>
+            </div>
+            <div>
+                <plex-label type="success" direction="column" size="xl" titulo="Prueba icono" subtitulo="Desacoplado">
+                    <plex-icon type="success" name="account"></plex-icon>
+                </plex-label>
+            </div>
+            <div>
+                <plex-label type="success" direction="column" size="xl">
+                    <plex-icon type="success" name="account"></plex-icon>
+                    Titulo aparte
+                </plex-label>
+            </div>
+        </section>
+        <plex-title titulo="Size='lg' | direction='column'" size="sm"></plex-title>
+        <section class="plex-grid">
+            <div *ngFor="let dato of datos | slice:1:4">
+                <plex-label size="lg" direction="column" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
+                </plex-label>
+            </div>
+        </section>
+        <plex-title titulo="Size='md'(default) | direction='row(default)'" size="sm"></plex-title>
+        <section class="plex-grid">
+            <div *ngFor="let dato of datos | slice:0:3">
+                <plex-label size="md" titulo="{{ dato.label }}" icon="star" subtitulo="{{ dato.valor }}">
+                </plex-label>
+            </div>
+        </section>
+        <plex-title titulo="Size='sm' | direction='row(default)'" size="sm"></plex-title>
+        <section class="plex-grid">
+            <div *ngFor="let dato of datos | slice:3:6">
+                <plex-label size="sm" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
+                </plex-label>
+            </div>
+        </section>
+        <plex-title titulo="Cronología invert" size="sm"></plex-title>
+        <plex-label *ngFor="let fecha of eventos | slice:0:5" type="info" size="md" direction="row"
+                    titulo="{{ fecha.type }}" subtitulo="{{ fecha.valor }}">
+            <p dato>{{ fecha.label }}</p>
+        </plex-label>
+    </plex-layout-sidebar>
 
 </plex-layout>

--- a/src/lib/css/plex-label.scss
+++ b/src/lib/css/plex-label.scss
@@ -28,17 +28,37 @@
     }
 
     // Icono
-    i {
+    i, [dato] {
         border: solid 2px;
         border-radius: 50%;
         padding: 5px 7px;
+        margin: 0 .75rem;
+    }
+
+    section {
+        position: relative;
+    }
+    
+    // dato en lugar de icono
+    p[dato] {
+        font-size: inherit;
+        border: solid 2px;
+        border-radius: 25px;
+        padding: 5px 13px;
+        width: fit-content;
+        height: fit-content;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        align-self: center;
+        margin-bottom: 0!important;
     }
 
     &.flex-row {
-
         // Icono
-        plex-icon > i {
-            margin-right: .5rem;
+        plex-icon {
+            //margin-right: .5rem;
+            align-self: center;
         }
     }
 
@@ -64,10 +84,10 @@
     }
 
     &.flex-row {
-
         // Icono
         plex-icon > i {
-            margin-right: .5rem;
+            //margin-right: .5rem;
+            align-self: center;
         }
     }
 

--- a/src/lib/label/label.component.ts
+++ b/src/lib/label/label.component.ts
@@ -1,29 +1,35 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ElementRef, AfterViewInit } from '@angular/core';
 
 @Component({
     selector: 'plex-label',
     template: `
-        <div class="plex-label {{ size }} d-flex flex-{{direction}}" [ngClass]="{ 'align-items-center': direction === 'column' }">
-            <plex-icon *ngIf="icon" name="{{icon}}" class="text-{{ type }}"></plex-icon>
-            <ng-content select="plex-icon"></ng-content>
-
-            <div class="d-flex flex-column" [ngClass]="{ 'align-items-center mt-2': direction === 'column' }">
-                <span *ngIf="titulo" class="text-{{ type }}" [ngClass]="{'font-weight-bold': tituloBold}">{{ titulo }}</span>
-                <small *ngIf="titulo && subtitulo">{{ subtitulo }}</small>
-            </div>
-            <ng-content *ngIf="!titulo && !subtitulo"></ng-content>
-        </div>
+    <div class="plex-label {{ size }} d-flex flex-{{direction}}" [ngClass]="{ 'align-items-center': direction === 'column' }">
+    <plex-icon *ngIf="icon && !datos" name="{{icon}}" class="text-{{ type }}"></plex-icon>
+    <ng-content select="plex-icon"></ng-content>
+    <ng-content select="[dato]"></ng-content>
+    <div class="d-flex flex-column" [ngClass]="direction === 'column' ? 'align-items-center mt-2 px-4' : ''">
+        <span *ngIf="titulo" class="text-{{ type }}" [ngClass]="{'font-weight-bold': tituloBold}">{{ titulo }}</span>
+        <small *ngIf="titulo && subtitulo" class="">{{ subtitulo }}</small>
+    </div>
+    <ng-content *ngIf="!titulo && !subtitulo"></ng-content>
+</div>
     `
 })
-export class PlexLabelComponent {
+export class PlexLabelComponent implements AfterViewInit {
     @Input() titulo: string;
     @Input() tituloBold = true;
     @Input() subtitulo: string;
     @Input() size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
     @Input() icon: string;
+    @Input() dato: string;
     @Input() direction: 'column' | 'row' = 'row';
     @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'default';
 
-    constructor() {
+    public datos = false;
+
+    ngAfterViewInit() {
+        this.datos = !!this.datRef.nativeElement.querySelector('[dato]');
     }
+
+    constructor(private datRef: ElementRef) { }
 }


### PR DESCRIPTION
Extiende componente permitiendo albergar dato alfanumérico en lugar de icono

- El dato mantiene el tratamiento visual del icono (hereda border y sizes).
- El dato acompaña la direccionalidad del plex-label ('row' como 'column').
- Se procura que si hay icono, no hay dato alfanumérico y viceversa.

**Next:** en un [PR futuro](https://github.com/andes/plex/tree/PLEX-64) se incluyen las líneas que conectan los distinto items que conforman una conjunto de labels _(ej.: línea de tiempo)_.

![label-alfanumérico](https://user-images.githubusercontent.com/5895886/97897527-5efba180-1d15-11eb-8756-3de3c7628b48.JPG)
