### PR TITLE
fix(plex-grid/plex-card): ajusta celdas, extiende elementos en card 

### DIFF
--- a/src/lib/card/card.component.ts
+++ b/src/lib/card/card.component.ts
@@ -8,6 +8,7 @@ import { Component, Input } from '@angular/core';
         <div class="d-flex" [ngClass]="cssAlign">
             <ng-content select="plex-badge"></ng-content>
         </div>
+        <ng-content></ng-content>
         <div class="d-flex my-2" [ngClass]="cssAlign">
             <ng-content select="plex-label"></ng-content>
         </div>

--- a/src/lib/css/plex-card.scss
+++ b/src/lib/css/plex-card.scss
@@ -25,7 +25,8 @@ plex-card {
     .card {
         display: flex;
         padding: 1.5rem;
-        height: 100%;    
+        height: 100%;
+        justify-content: space-between;
     }
 
     // Estados

--- a/src/lib/css/plex-card.scss
+++ b/src/lib/css/plex-card.scss
@@ -24,7 +24,8 @@ plex-card {
 
     .card {
         display: flex;
-        padding: 1.5rem;    
+        padding: 1.5rem;
+        height: 100%;    
     }
 
     // Estados

--- a/src/lib/css/plex-grid.scss
+++ b/src/lib/css/plex-grid.scss
@@ -8,6 +8,13 @@ plex-grid {
     text-transform: capitalize;
     grid-template-columns: repeat(var(--type), minmax(var(--colSize), 1fr));	
 
+    plex-card {
+        img {
+            object-fit: contain!important;
+            max-height: var(--rowSize);
+        }
+    }
+
     // labels 
     span {	
         white-space: wrap;	
@@ -16,10 +23,9 @@ plex-grid {
     }	
 
     img {
-        object-fit: cover;	
+        object-fit: cover;
         width: 100%;
-        height: fit-content;
-        max-height: var(--rowSize);	
+        height: var(--colSize);
     }
     
     // types


### PR DESCRIPTION
**plex-grid:**

- Se cambia valor del height de celdas a 100% (para lograr equidad en los altos).
- Se corrige anidación de propiedades para evitar herencia de estilos en las imágenes.

**plex-card:**
- Se permite contenido libre <ng-content> antes restringido a plex-badge, plex-button y plex-label.
- Se realizan ajustes en la distribución de estos elementos (margin, justify).

Estos fixes surgen para cubrir necesidades detectadas en la creación del componente [shared-galeria-archivos](https://github.com/andes/app/tree/PLEX-180)

Para testear bajarse la rama [PLEX-180](https://github.com/andes/app/tree/PLEX-180) de la app y apuntar a está rama reinstalando Plex (npm i andes/plex#PLEX-180)

![shared-galeria-archivos](https://user-images.githubusercontent.com/5895886/98838548-2fd6e580-2423-11eb-8366-f9dc37eea323.gif)
