### PR TITLE
fix(layout/card): restringe animation, reordena contenido 

### DIFF
--- a/src/lib/card/card.component.ts
+++ b/src/lib/card/card.component.ts
@@ -5,17 +5,19 @@ import { Component, Input } from '@angular/core';
     template: `
     <div class="card bg-{{ type }}" [ngClass]="{'text-white' : type != 'default'}" [class.selected]="selected">
         <ng-content select="img"></ng-content>
+        <ng-content select="plex-icon"></ng-content>
         <div class="d-flex" [ngClass]="cssAlign">
             <ng-content select="plex-badge"></ng-content>
         </div>
-        <ng-content></ng-content>
-        <div class="d-flex my-2" [ngClass]="cssAlign">
+        <div class="d-flex mt-2" [ngClass]="cssAlign">
             <ng-content select="plex-label"></ng-content>
         </div>
-        <div class="d-flex" [ngClass]="cssAlign">
+        <div class="d-flex flex-column mt-2" [ngClass]="cssAlign">
+            <ng-content></ng-content>
+        </div>
+        <div class="d-flex mt-2" [ngClass]="cssAlign">
             <ng-content select="plex-button"></ng-content>
         </div>
-            <ng-content select="plex-bool"></ng-content>
     </div>
     `,
 })
@@ -30,6 +32,10 @@ export class PlexCardComponent {
     }
 
     get cssAlign() {
-        return this.align === 'start' ? 'justify-content-start' : 'justify-content-center';
+        if (this.align === 'center') {
+            return 'justify-content-center';
+        } else {
+            return this.align === 'start' ? 'justify-content-start' : 'justify-content-end';
+        }
     }
 }

--- a/src/lib/css/layout.scss
+++ b/src/lib/css/layout.scss
@@ -66,8 +66,8 @@ plex-layout {
         }
     }
 
-    > section {
-        >div.row {
+    &[resizable="true"] > section {
+        > div.row {
             div[class^="col-"] {
                 transition: all 900ms ease;
                 

--- a/src/lib/css/mixins/cardBackground.scss
+++ b/src/lib/css/mixins/cardBackground.scss
@@ -1,0 +1,17 @@
+@mixin cardBackground{
+    plex-badge > span.badge {
+        color: white!important;
+        border-color: white!important;
+    }
+
+    plex-button > button.btn {
+        background: white!important;
+        border: none!important;
+        box-shadow: none!important;
+        color: var(--color-base)!important;
+    
+        &:hover {
+            background: var(--color-baseLight)!important;
+        }
+    }
+}

--- a/src/lib/css/plex-card.scss
+++ b/src/lib/css/plex-card.scss
@@ -1,24 +1,7 @@
 @import './variables.scss';
-@mixin cardBackground{
-    plex-badge > span.badge {
-        color: white!important;
-        border-color: white!important;
-    }
-
-    plex-button > button.btn {
-        background: white!important;
-        border: none!important;
-        box-shadow: none!important;
-        color: var(--color-base)!important;
-    
-        &:hover {
-            background: var(--color-baseLight)!important;
-        }
-    }
-}
+@import './mixins/cardBackground.scss';
 
 plex-card {
-    
     cursor: pointer;
     box-sizing: border-box;
 
@@ -27,8 +10,12 @@ plex-card {
         padding: 1.5rem;
         height: 100%;
         justify-content: space-between;
+        
+        > img, > plex-icon {
+            margin-bottom: .75rem;
+        }
     }
-
+    
     // Estados
     > .card:hover {
         color: var(--color-tipo)!important;


### PR DESCRIPTION
**FIXES:**
**plex-layout:**
- Se restringe la animación del layout mediante el atributo` [reizable]="true"`.

**plex-card:**
- Se reordenan los elementos internos.
- Se agrega espaciado y flex al `<ng-content>`.
- Se agrega la posibilidad de marginar elementos hacia la derecha.

![non-animation](https://user-images.githubusercontent.com/5895886/99119037-589fdc00-25d7-11eb-8a34-eeb4bc021955.gif)
