### PR TITLE
plex item custom color

### DIFF
--- a/src/demo/app/item-list/item-list.component.ts
+++ b/src/demo/app/item-list/item-list.component.ts
@@ -64,6 +64,28 @@ export class ItemDemoComponent implements OnInit {
     public tModel: any;
     tModelFecha: { fechaHora: any; fecha: any; hora: any; horados: any; disabled: boolean; min: Date; minHora: any; maxHora: any; };
 
+    // #2C7F00 #C6B300 #B70B0B #02111C
+    coloresPrioridadBaja = {
+        border: '#b0cfa0',
+        hover: '#80b266',
+        background: '#e9f2e5'
+    };
+    coloresPrioridadMedia = {
+        border: '#d5c743',
+        hover: '#C6B300',
+        background: '#f8f5de'
+    };
+    coloresPrioridadAlta = {
+        border: '#e4a4a4',
+        hover: '#B70B0B',
+        background: '#f8e6e6'
+    };
+    coloresPrioridadEspecial = {
+        border: '#7a6f93',
+        hover: '#02111C',
+        background: '#dddae3'
+    };
+
     ngOnInit() {
         // Template-Form1 model
         this.tModel = { valor: null };
@@ -130,6 +152,18 @@ export class ItemDemoComponent implements OnInit {
         this.lista.push({ name: 'MAS ITEMS' } as any);
         this.lista.push({ name: 'MAS ITEMS' } as any);
         this.lista.push({ name: 'MAS ITEMS' } as any);
+    }
+
+    prioridad(i) {
+        if (i < 3) {
+            return this.coloresPrioridadBaja;
+        } else if (i >= 3 && i < 6) {
+            return this.coloresPrioridadMedia;
+        } else if (i >= 6 && i < 9) {
+            return this.coloresPrioridadAlta;
+        } else if (i >= 9 && i < 12) {
+            return this.coloresPrioridadEspecial;
+        }
     }
 
 }

--- a/src/demo/app/item-list/item-list.html
+++ b/src/demo/app/item-list/item-list.html
@@ -27,8 +27,8 @@
                 <b label>Datos importantes</b>
                 <b label>Parentesco</b>
             </plex-heading>
-            <plex-item *ngFor="let item of lista; let par = even" [selected]="item.selected"
-                       (click)="item.selected = !item.selected">
+            <plex-item [colors]="prioridad(i)" *ngFor="let item of lista; let par = even; let i = index"
+                       [selected]="item.selected" (click)="item.selected = !item.selected">
                 <plex-bool [(ngModel)]="item.selected" name="activo"></plex-bool>
                 <plex-icon name="pencil" size="18" type="warning"></plex-icon>
                 <plex-label [titulo]="item.name" [tituloBold]="par">

--- a/src/lib/css/plex-item.scss
+++ b/src/lib/css/plex-item.scss
@@ -119,6 +119,10 @@ plex-list {
     }
 
     section.item {
+        --item-border-color: "#{$blue}";
+        --item-border-color-hover: #{transparentize($color: $blue, $amount: 0.4)};
+        --item-bg-color: #{$light-blue};
+
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -126,22 +130,25 @@ plex-list {
         padding: 0.75rem;
         width: 100%;
 
+        &.custom-colors {
+            box-shadow: inset 0 0 0 2px var(--item-border-color);
+            background-color: var(--item-bg-color) !important;
+        }
+
         &.selectable {
             cursor: pointer;
             &:hover {
                 box-sizing: border-box;
-                box-shadow: inset 0 0 0 2px transparentize($color: $blue, $amount: 0.4);
-                // border: 2px solid $blue;
-                background-color: $light-blue !important;
+                box-shadow: inset 0 0 0 2px var(--item-border-color-hover);
+                background-color: var(--item-bg-color) !important;
                 color: black;
             }
         }
 
         &.selected {
-            // border: 2px solid $blue;
             box-sizing: border-box;
-            box-shadow: inset 0 0 0 2px $blue;
-            background-color: $light-blue !important;
+            box-shadow: inset 0 0 0 2px var(--item-border-color);
+            background-color: var(--item-bg-color) !important;
             color: black;
         }
 

--- a/src/lib/item-list/item.component.ts
+++ b/src/lib/item-list/item.component.ts
@@ -8,7 +8,7 @@ import { PlexButtonComponent } from '../button/button.component';
 @Component({
     selector: 'plex-item',
     template: `
-        <section #item class="item" [class.custom-colors]="colors" [class.selectable]="selectable" [class.selected]="selectable && selected">
+        <section #item class="item" [class.custom-colors]="hasColors" [class.selectable]="selectable" [class.selected]="selectable && selected">
             <div class="item-row">
                 <div class="elementos-graficos">
                     <ng-content select="plex-bool"></ng-content>
@@ -36,7 +36,7 @@ import { PlexButtonComponent } from '../button/button.component';
         </section>
     `
 })
-export class PlexItemComponent implements AfterViewInit, OnChanges {
+export class PlexItemComponent implements AfterViewInit {
 
     // Permite :hover y click()
     @Input() selectable = true;
@@ -69,6 +69,10 @@ export class PlexItemComponent implements AfterViewInit, OnChanges {
         return this.plexButtons.length > 0 || this.plexBadges.length > 0;
     }
 
+    hasColors() {
+        return this.colors && this.colors.border && this.colors.hover && this.colors.background;
+    }
+
     ngAfterViewInit() {
         this.imgs = !!this.elRef.nativeElement.querySelector('img');
 
@@ -77,14 +81,11 @@ export class PlexItemComponent implements AfterViewInit, OnChanges {
 
 
         this.ref.detectChanges();
-        if (this.colors && this.colors.border && this.colors.hover && this.colors.background) {
+        if (this.hasColors) {
             this.item.nativeElement.style.setProperty('--item-border-color', this.colors.border);
             this.item.nativeElement.style.setProperty('--item-border-color-hover', this.colors.hover);
             this.item.nativeElement.style.setProperty('--item-bg-color', this.colors.background);
         }
-    }
-
-    ngOnChanges() {
     }
 
     constructor(

--- a/src/lib/item-list/item.component.ts
+++ b/src/lib/item-list/item.component.ts
@@ -1,5 +1,5 @@
 import { map } from 'rxjs/operators';
-import { Component, Input, QueryList, AfterViewInit, ContentChildren, ElementRef, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, QueryList, AfterViewInit, ContentChildren, ElementRef, ChangeDetectorRef, ViewChild, OnChanges } from '@angular/core';
 import { PlexIconComponent } from '../icon/icon.component';
 import { PlexBoolComponent } from '../bool/bool.component';
 import { PlexBadgeComponent } from '../badge/badge.component';
@@ -8,7 +8,7 @@ import { PlexButtonComponent } from '../button/button.component';
 @Component({
     selector: 'plex-item',
     template: `
-        <section class="item" [class.selectable]="selectable" [class.selected]="selectable && selected">
+        <section #item class="item" [class.custom-colors]="colors" [class.selectable]="selectable" [class.selected]="selectable && selected">
             <div class="item-row">
                 <div class="elementos-graficos">
                     <ng-content select="plex-bool"></ng-content>
@@ -36,7 +36,7 @@ import { PlexButtonComponent } from '../button/button.component';
         </section>
     `
 })
-export class PlexItemComponent implements AfterViewInit {
+export class PlexItemComponent implements AfterViewInit, OnChanges {
 
     // Permite :hover y click()
     @Input() selectable = true;
@@ -44,10 +44,15 @@ export class PlexItemComponent implements AfterViewInit {
     // Muestra efecto de selección
     @Input() selected = false;
 
+    @Input() colors: any = {};
+
     @ContentChildren(PlexIconComponent, { descendants: false }) plexIcons: QueryList<PlexIconComponent>;
     @ContentChildren(PlexBoolComponent, { descendants: false }) plexBools: QueryList<PlexBoolComponent>;
     @ContentChildren(PlexBadgeComponent, { descendants: false }) plexBadges: QueryList<PlexBadgeComponent>;
     @ContentChildren(PlexButtonComponent, { descendants: false }) plexButtons: QueryList<PlexButtonComponent>;
+
+    @ViewChild('item', { static: true }) item: ElementRef;
+
 
     public imgs = false;
     public svgs = false;
@@ -70,7 +75,16 @@ export class PlexItemComponent implements AfterViewInit {
         const elementos = this.elRef.nativeElement.querySelectorAll('.item-list > svg');
         this.svgs = elementos.length > 0;
 
+
         this.ref.detectChanges();
+        if (this.colors && this.colors.border && this.colors.hover && this.colors.background) {
+            this.item.nativeElement.style.setProperty('--item-border-color', this.colors.border);
+            this.item.nativeElement.style.setProperty('--item-border-color-hover', this.colors.hover);
+            this.item.nativeElement.style.setProperty('--item-bg-color', this.colors.background);
+        }
+    }
+
+    ngOnChanges() {
     }
 
     constructor(


### PR DESCRIPTION
Asigna un esquema de color a un item, usando 3 propiedades:
1. `background`
2. `border`
3. `hover` border durante el evento _hover_

Funciona a través de un `@Input() colors` que espera el siguiente formato:
```
misColores = {
        border: '#b0cfa0',
        hover: '#80b266',
        background: '#e9f2e5'
};
...
<plex-item [colors]="misColores" ...>
```