### PR TITLE
feat(plex-button): autodisabled prop

### DIFF
--- a/cypress/integration/button.js
+++ b/cypress/integration/button.js
@@ -1,0 +1,28 @@
+/// <reference types="Cypress" />
+
+context('button', () => {
+    before(() => {
+        cy.eyesOpen({ appName: 'PLEX', testName: 'button-badge' });
+
+        cy.visit('/button-badge');
+    });
+
+    it('test button', () => {
+        cy.server();
+        cy.route({
+            method: 'POST',
+            url: 'https://jsonplaceholder.typicode.com/posts',
+            delay: 1000,
+            response: {}
+        })
+        cy.eyesCheckWindow('main - button');
+
+        cy.plexButton('Default').click();
+        cy.plexButton('Default').should('have.attr', 'disabled');
+        cy.wait(1000);
+        cy.plexButton('Default').should('not.have.attr', 'disabled');
+
+        cy.eyesClose();
+
+    });
+});

--- a/src/demo/app/button/button.component.ts
+++ b/src/demo/app/button/button.component.ts
@@ -1,5 +1,6 @@
 import { Plex } from './../../../lib/core/service';
 import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
     templateUrl: 'button.html',
@@ -11,14 +12,23 @@ export class ButtonDemoComponent implements OnInit {
 
     color = 'red';
 
-    constructor(private plex: Plex) { }
+    constructor(
+        private plex: Plex,
+        private server: HttpClient
+    ) { }
 
     ngOnInit(): void {
         this.plex.updateTitle([{ name: 'Plex', route: '/' }, { name: 'Button' }]);
     }
 
     onClick() {
-        alert('Click handler was fired');
+        this.server.post('https://jsonplaceholder.typicode.com/posts', {}).subscribe(() => {
+
+        });
+        this.server.post('https://jsonplaceholder.typicode.com/posts', {}).subscribe(() => {
+
+        });
+        // alert('Click handler was fired');
     }
 
     onDisabledClick() {

--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -4,12 +4,12 @@
         <hr>
 
         <plex-title size="sm" titulo="Tipos"></plex-title>
-        <plex-button label="Default" (click)="onClick()"></plex-button>
+        <plex-button label="Default" (click)="onClick()" [autodisabled]="true"></plex-button>
         <plex-button label="Info" type="info"></plex-button>
         <plex-button label="Danger" type="danger"></plex-button>
         <plex-button label="Warning" type="warning"></plex-button>
         <plex-button label="Success" type="success"></plex-button>
-        <plex-button label="Link" type="link"></plex-button>
+        <plex-button label="Link" type="link" [autodisabled]="true"></plex-button>
         <hr>
         <plex-title size="sm" titulo="Estados"></plex-title>
         <plex-button label="Deshabilitado" [disabled]="true" (click)="onDisabledClick()"></plex-button>

--- a/src/lib/button/button.component.spec.ts
+++ b/src/lib/button/button.component.spec.ts
@@ -5,6 +5,7 @@ import { Component, DebugElement, Type, ViewChild, ViewEncapsulation } from '@an
 import { PlexButtonComponent } from './button.component';
 import { PlexModule } from '../module';
 import { FormsModule } from '@angular/forms';
+import { Plex } from '../core/service';
 
 describe('PlexButtonComponent', () => {
 
@@ -142,7 +143,8 @@ function createTestingModule<T>(cmp: Type<T>, template: string): ComponentFixtur
 
     TestBed.configureTestingModule({
         imports: [BrowserModule, PlexModule, FormsModule],
-        declarations: [cmp]
+        declarations: [cmp],
+        providers: [Plex]
     })
         .overrideComponent(cmp, {
             set: {

--- a/src/lib/core/network-loading.service.ts
+++ b/src/lib/core/network-loading.service.ts
@@ -21,6 +21,10 @@ export class NetworkLoadingInterceptor implements HttpInterceptor {
             return next.handle(req);
         }
 
+        if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+            this.plex.updateNetwork('inc');
+        }
+
         this.plex.showLoader();
 
         this.count++;
@@ -30,6 +34,10 @@ export class NetworkLoadingInterceptor implements HttpInterceptor {
                 this.count--;
 
                 this.plex.hideLoader();
+
+                if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+                    this.plex.updateNetwork('dec');
+                }
             })
         );
     }

--- a/src/lib/core/service.ts
+++ b/src/lib/core/service.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { Injectable, ViewContainerRef, ComponentFactoryResolver } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { DropdownItem } from './../dropdown/dropdown-item.inteface';
@@ -17,6 +17,10 @@ export class Plex {
     public userInfo: any;
     public navbarVisible = true;
 
+    /**
+     * Cuenta los POST, PATCH, PUT, DELETE
+     */
+    public networkCounter = new BehaviorSubject(0);
     /**
      * Contiene el título y breadcrumb que se muestran en el navbar
      */
@@ -404,5 +408,17 @@ export class Plex {
      */
     isMobile() {
         return this.breakpointObserver.isMatched('(max-width: 599px)');
+    }
+
+    updateNetwork(action: 'inc' | 'dec') {
+        const count = this.networkCounter.getValue();
+        if (action === 'inc') {
+            this.networkCounter.next(count + 1);
+        } else {
+            if (count > 0) {
+                this.networkCounter.next(count - 1);
+            }
+
+        }
     }
 }

--- a/src/lib/datetime/datetime.component.spec.ts
+++ b/src/lib/datetime/datetime.component.spec.ts
@@ -6,6 +6,7 @@ import { Component, DebugElement, Type, ViewChild } from '@angular/core';
 import { PlexDateTimeComponent } from './datetime.component';
 import { PlexModule } from '../module';
 import { FormsModule } from '@angular/forms';
+import { Plex } from '../core/service';
 
 describe('PlexDateTimeComponent', () => {
     describe('input simple text', () => {
@@ -161,7 +162,8 @@ function createTestingModule<T>(cmp: Type<T>, template: string): ComponentFixtur
 
     TestBed.configureTestingModule({
         imports: [BrowserModule, PlexModule, FormsModule],
-        declarations: [cmp]
+        declarations: [cmp],
+        providers: [Plex]
     })
         .overrideComponent(cmp, {
             set: {


### PR DESCRIPTION
Agrega propiedad **autodisabled** a plex-button, un botón marcado con esta propiedad se pone automáticamente en disabled si hay un request del tipo POST, PUT, PATCH, DELETE en progreso. (uno o varios). 

El único detalle que se observa es que si en la pantalla hay dos botones diferentes con esta propiedad los dos se ponen automáticamente en disabled. Indistintamente el que se haya apretado. De todas manera debe ser un caso poco usual. 

