### PR TITLE
Plex text typing

### DIFF
--- a/src/demo/app/datetime/datetime.component.ts
+++ b/src/demo/app/datetime/datetime.component.ts
@@ -42,7 +42,9 @@ export class DateTimeDemoComponent implements OnInit {
     onBlur() {
     }
 
-    onChange(date) {
+    onType() {
+    }
 
+    onChange(date) {
     }
 }

--- a/src/demo/app/datetime/datetime.html
+++ b/src/demo/app/datetime/datetime.html
@@ -53,7 +53,7 @@
 
                     <plex-datetime label="Datetime con debounce" name="debounce" type="date"
                                    [(ngModel)]="tModel.fechaDecounce" (change)="onChange($event)" [debounce]="1000"
-                                   hintAction="nextDay" hintIcon="chevron-right">
+                                   hintAction="nextDay" hintIcon="chevron-right" (typing)="onType()">
                     </plex-datetime>
 
                     <plex-datetime [(ngModel)]="tModel.fechaDecounce" name="onlybtn" required [btnOnly]="true"

--- a/src/lib/datetime/datetime.component.ts
+++ b/src/lib/datetime/datetime.component.ts
@@ -107,6 +107,7 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges, 
     @Output() change = new EventEmitter();
     @Output() blur = new EventEmitter();
     @Output() focus = new EventEmitter();
+    @Output() typing = new EventEmitter();
 
     // Funciones públicas
     public onChange = (_: any) => { };
@@ -246,6 +247,7 @@ export class PlexDateTimeComponent implements OnInit, AfterViewInit, OnChanges, 
                     value
                 });
             }, this.debounce);
+            this.typing.emit();
         };
     }
 

--- a/src/lib/text/text.component.ts
+++ b/src/lib/text/text.component.ts
@@ -117,6 +117,7 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
     @Output() change = new EventEmitter();
     @Output() focus = new EventEmitter();
     @Output() focusout = new EventEmitter();
+    @Output() typing = new EventEmitter();
 
     public onFocus() {
         this.focus.emit();
@@ -213,6 +214,7 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
                     value
                 });
             }, this.debounce);
+            this.typing.emit();
         };
     }
 


### PR DESCRIPTION
Agrega @Output en plex-text y plex-datetime indicando que el usuario esta escribiendo. Útil cuando el elemento tiene la propiedad debounce pero se quiere deshabilitar un botón apenas arranca a escribir hasta que se ejecute el GET a la base de datos. 

Con la propiedad debounce el evento Change se pospone dando unos milisegundo de changui al usuario de apretar algo.