### PR TITLE
fix(plex-accordion): resuelve superposición al alojar componentes desplegables

### DIFF
--- a/src/demo/app/accordion/accordion.component.ts
+++ b/src/demo/app/accordion/accordion.component.ts
@@ -1,10 +1,55 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { SelectEvent } from './../../../lib/select/select-event.interface';
+import { ServiceDemoSelect } from './../../app/select/select.service';
 
 @Component({
     templateUrl: 'accordion.html',
 })
-export class AccordionDemoComponent {
+export class AccordionDemoComponent implements OnInit {
     public test = false;
+    public opciones: any[];
+    public modelo1 = { select: null };
+    public modelo2 = {
+        select: null,
+        soloLectura: false,
+        selectMultiple: null,
+        disabled: false,
+        required: true
+    };
+
+    constructor(
+        public servicio: ServiceDemoSelect
+    ) {
+    }
+
+    ngOnInit() {
+        // Opciones
+        this.opciones = [{
+            id: 1,
+            nombre: 'Argentina',
+            continente: 'Latinoamerica',
+        },
+        {
+            id: 2,
+            nombre: 'Brasil',
+            continente: 'Latinoamerica',
+        },
+        {
+            id: 3,
+            nombre: 'Chile',
+            continente: 'Latinoamerica',
+        }];
+
+        this.modelo1.select = this.modelo2.select = this.opciones[1];
+    }
+
+    loadData(event: SelectEvent) {
+        if (event.query) {
+            this.servicio.get(event.query).subscribe(event.callback);
+        } else {
+            event.callback(null);
+        }
+    }
 
     toggle(showed) {
     }

--- a/src/demo/app/accordion/accordion.html
+++ b/src/demo/app/accordion/accordion.html
@@ -17,6 +17,10 @@
             </plex-panel>
             <plex-panel icon="history" tituloPrincipal="Título con ícono">
                 SEGUNDO PANEL
+                <plex-select [(ngModel)]="modelo2.selectMultiple" [multiple]="true" name="selectmultiple"
+                             (getData)="loadData($event)" label="Múltiple con llamada a la API"
+                             [readonly]="modelo2.soloLectura" placeholder="Ingrese un país">
+                </plex-select>
             </plex-panel>
             <plex-panel icon="youtube" tituloPrincipal="Video embebido" tituloSecundario="Psychocandy!">
                 <iframe width="560" height="315" src="https://www.youtube.com/embed/iFp7W3PoNPI?ecver=1" frameborder="0"

--- a/src/lib/css/plex-accordion.scss
+++ b/src/lib/css/plex-accordion.scss
@@ -47,6 +47,7 @@ plex-accordion {
     opacity: 0;
     &.show {
       animation: accordion ease-in-out 0.25s forwards;
+      z-index: 1;
     }
   }
 }


### PR DESCRIPTION
**Problema**
Existe superposición al desplegarse un plex-select alojado dentro de un plex-accordion con los cabezales de otros elementos.

https://user-images.githubusercontent.com/5895886/103659558-501ab080-4f4b-11eb-8437-e31e9144cbcd.mp4

**Solución**
Se agrega la propiedad z-index con valor '1' al panel desplegado del accordion de modo que su contenido quede por encima del resto de los elementos.

https://user-images.githubusercontent.com/5895886/103659750-8ce6a780-4f4b-11eb-9e49-01c74567a706.mp4


**Plus**
Se modifica demo de accordion reproduciendo la situación de uso