### PR TITLE
feat(plex-badge): agrega selector para dato numérico

### DIFF
--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -65,7 +65,7 @@
             <plex-button icon="clock" size="sm"></plex-button>
         </plex-badge>
         <plex-badge size="sm" type="info" class="mr-1">14/02/2020
-            <plex-button icon="clock" size="sm"></plex-button>
+            <span dato>11</span>
         </plex-badge>
 
         <plex-badge size="sm" [color]="color" class="mr-1">

--- a/src/lib/badge/badge.component.ts
+++ b/src/lib/badge/badge.component.ts
@@ -12,6 +12,7 @@ import { Component, Input, ElementRef, ViewChild, OnChanges } from '@angular/cor
         <span #badgeBtn class="btn-badge btn-badge-{{ type }}">
             <ng-content select="plex-button"></ng-content>
             <ng-content select="plex-datetime"></ng-content>
+            <ng-content select="span[dato]"></ng-content>
         </span>
         `,
 })

--- a/src/lib/css/plex-badge.scss
+++ b/src/lib/css/plex-badge.scss
@@ -83,6 +83,15 @@ plex-badge {
             position: relative;
             right: 2px;
         }
+        span[dato] {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background-color: var(--badge-color);
+            color: white;
+            padding: 0.27rem 0.5rem;
+            font-size: $badge-font-size;
+        }
     }
 }
 


### PR DESCRIPTION
**Problema**
Se debe agregar un bloque de código y diversas clases manualmente para lograr incorporar un número junto al badge.

**Solución**
Se agrega un selector [dato] en el template y las clases correspondientes directamente en la hoja de estilo del componente.

![badge-label](https://user-images.githubusercontent.com/5895886/103693372-ef559d00-4f77-11eb-9d59-ae7acd0caca5.JPG)
