### PR TITLE
fix(plex-table): corrige clases selected/selectable

### DIFF
--- a/src/demo/app/table/table.html
+++ b/src/demo/app/table/table.html
@@ -2,7 +2,7 @@
     <plex-layout-main>
         <plex-table [columns]="columns" #table="plTable">
             <plex-title titulo="HOLA">
-                <plex-table-columns [selected]="colsVisibles">
+                <plex-table-columns>
                 </plex-table-columns>
             </plex-title>
 

--- a/src/demo/app/table/table.html
+++ b/src/demo/app/table/table.html
@@ -7,7 +7,7 @@
             </plex-title>
 
             <tr *ngFor="let item of (data$ | plSort:table | async)" [class.selected]="item.selected"
-                (click)="item.selected = !item.selected">
+                (click)="item.selected = !item.selected" [class.selectable]="selectable">
                 <td *plTableCol="'col-1'">{{item.nombre }}</td>
                 <td *plTableCol="'col-2'">{{ item.apellido }}</td>
                 <td *plTableCol="'col-3'">{{item.documento}}</td>

--- a/src/lib/css/plex-table.scss
+++ b/src/lib/css/plex-table.scss
@@ -11,7 +11,7 @@ plex-table {
             top: 0!important;
             z-index: 10!important;
             height: fit-content;
-            background-color: rgba(255, 255, 255, 0.65)!important;
+            background-color: rgba(255, 255, 255, 0.5)!important;
 
             &.sortable {
 
@@ -19,30 +19,35 @@ plex-table {
                     text-decoration: underline !important;
                     cursor: pointer;
                 }
+
+                > span {
+                    position: absolute;
+                    top: 15px;
+                }
+
             }
         }
 
         tr {
-            &:nth-child(odd) {
-                background-color: rgba(0, 39, 56, 0.1);
+            &.selectable {
+                cursor: pointer;
+                &:hover {
+                    box-sizing: border-box;
+                    box-shadow: inset 0 0 0 2px transparentize($color: $blue, $amount: 0.4);
+                    background-color: $light-blue !important;
+                    color: black;
+                }
             }
-        }
-
-        &.selectable {
-            cursor: pointer;
-            &:hover {
+    
+            &.selected {
                 box-sizing: border-box;
-                box-shadow: inset 0 0 0 2px transparentize($color: $blue, $amount: 0.4);
+                box-shadow: inset 0 0 0 2px $blue;
                 background-color: $light-blue !important;
                 color: black;
             }
-        }
-
-        &.selected {
-            box-sizing: border-box;
-            box-shadow: inset 0 0 0 2px $blue;
-            background-color: $light-blue !important;
-            color: black;
+            &:nth-child(odd) {
+                background-color: rgba(0, 39, 56, 0.1);
+            }
         }
             
         & th, td {
@@ -55,6 +60,10 @@ plex-table {
                 display: flex;
                 justify-content: flex-end;
                 text-align: right;
+
+                > span {
+                    right: 0;
+                }
         
                 plex-button, plex-badge, plex-dropdown {
                     align-self: center;
@@ -73,7 +82,7 @@ plex-layout-sidebar {
     table {
         thead {
             th {
-                background-color: rgba(0, 39, 56, 0.65)!important;
+                background-color: rgba(0, 39, 56, 0.5)!important;
             }
         }
 

--- a/src/lib/table/table-column-dropdown.component.ts
+++ b/src/lib/table/table-column-dropdown.component.ts
@@ -1,5 +1,6 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
+import { first, tap } from 'rxjs/operators';
 import { PlexColumnDirective } from './columns.directive';
 import { IPlexColumnDisplay, IPlexTableColumns } from './table.interfaces';
 
@@ -17,9 +18,9 @@ import { IPlexColumnDisplay, IPlexTableColumns } from './table.interfaces';
         </plex-dropdown>
     `,
 })
-export class PlexTableColumnsComponent implements OnChanges {
+export class PlexTableColumnsComponent implements OnChanges, OnInit {
 
-    @Input() selected: IPlexColumnDisplay = {};
+    @Input() selected: IPlexColumnDisplay = null;
 
     @Output() change = new EventEmitter<IPlexColumnDisplay>();
 
@@ -37,6 +38,20 @@ export class PlexTableColumnsComponent implements OnChanges {
             this.table.setColumnHandler(this);
         }
 
+    }
+
+    ngOnInit() {
+        if (!this.selected) {
+            this.columns$.pipe(
+                first(),
+                tap(cols => {
+                    cols.forEach(col => {
+                        this.estadoColumnas[col.key] = true;
+                    });
+                    this.change.emit({ ...this.estadoColumnas });
+                })
+            ).subscribe();
+        }
     }
 
     ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
- Se corrige clase selected y selectable.
- Se corrige efecto indeseado en cabezal al aparecer las flechitas al lado de cada `<th>`.
- Se baja opacidad del cabezal fijo al scrollear.

**Next:**
- Todas las columnas visibles por default
- Posibilidad de fijar plex-title embebido en plex-table (selector 'main')


https://user-images.githubusercontent.com/5895886/104818526-e5992880-5806-11eb-9dfe-03602ce4e014.mp4

