### PR TITLE
feat(plex-grid): extiende encolumnado y spanDirective

### DIFF
--- a/src/demo/app/card/card.component.html
+++ b/src/demo/app/card/card.component.html
@@ -62,8 +62,10 @@
         <plex-title titulo="atributos y usos"></plex-title>
         <plex-title titulo="detalle de agendas" size="sm"></plex-title>
         <plex-grid type="full" size="md">
-            <plex-card align="start" type="" *ngFor="let agenda of agendas">
-                <plex-badge type="{{ agenda.type }}">{{ agenda.turnos }}</plex-badge>
+            <plex-card align="start" type="" *ngFor="let agenda of agendas"
+                       [ngClass]="{'disabled' : agenda.turnos === 'sin turnos'}">
+                <plex-badge type="{{ agenda.type }}">{{
+                    agenda.turnos }}</plex-badge>
                 <plex-label size="md" direction="row" titulo="{{ agenda.horario }}"
                             subtitulo="{{ agenda.profesional }}">
                 </plex-label>

--- a/src/demo/app/card/card.component.html
+++ b/src/demo/app/card/card.component.html
@@ -8,18 +8,19 @@
             <div>
                 <plex-title titulo="plex-card align=start" size="sm"></plex-title>
                 <plex-grid type="auto" size="lg">
-                    <plex-card align="start" type="{{ dato.type }}" *ngFor="let dato of datos | slice:0:5"
-                               [selected]="dato.selected" (click)="dato.selected = !dato.selected">
+                    <plex-card [color]="color" align="start" type="{{ dato.type }}"
+                               *ngFor="let dato of datos | slice:0:6" [selected]="dato.selected"
+                               (click)="dato.selected = !dato.selected">
                         <plex-badge type="warning">badge</plex-badge>
                         <plex-label size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
 
                         </plex-label>
                         <plex-button type="warning" label="aceptar"></plex-button>
                     </plex-card>
-                    <plex-card class="mt-1" align="start" type="dark" *ngFor="let dato of datos | slice:5:6"
+                    <plex-card span="2" class="mt-1" align="center" type="dark" *ngFor="let dato of datos | slice:6:7"
                                [selected]="dato.selected" (click)="dato.selected = !dato.selected">
                         <plex-badge type="warning">badge</plex-badge>
-                        <plex-label size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
+                        <plex-label direction="column" size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
                                     icon="information-variant">
                         </plex-label>
                         <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>

--- a/src/demo/app/card/card.component.ts
+++ b/src/demo/app/card/card.component.ts
@@ -5,13 +5,16 @@ import { Component } from '@angular/core';
 })
 export class CardDemoComponent {
 
+    color = '#92278e';
+
     datos = [
         { label: 'Funcionar como botones destacados en una interfaz', valor: 'Por ejemplo en puntos de inicio', type: 'default' },
         { label: 'Representar opciones seleccionables', valor: 'Usuarios, organizaciones, items propios de un módulo', type: 'success' },
         { label: 'Enriquecer las celdas de una grilla', valor: 'Por este motivo se combina con el componente plex-grid', type: 'info' },
         { label: 'Card Warning', valor: 'Es un elemento seleccionable', type: 'warning' },
         { label: 'Card Danger', valor: 'Es un elemento seleccionable', type: 'danger' },
-        { label: 'Definir bloques de información destacada', valor: 'Recomendable la tipología "invert"', type: 'success' },
+        { label: 'Card custom', valor: 'El color se define mediante el atributo [color]', type: 'custom' },
+        { label: 'Definir bloques de información destacada', valor: 'Recomendable la tipología "invert"', type: 'custom' },
     ];
 
     agendas = [

--- a/src/lib/card/card.component.ts
+++ b/src/lib/card/card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, ViewChild, ElementRef, OnChanges } from '@angular/core';
 
 @Component({
     selector: 'plex-card',
@@ -22,7 +22,7 @@ import { Component, Input, ViewChild, ElementRef } from '@angular/core';
     `,
 })
 
-export class PlexCardComponent {
+export class PlexCardComponent implements OnChanges {
     @Input() selected = false;
     @Input() align: 'start' | 'end' | 'center' = 'center';
     @Input() size: 'xs' | 'md' | 'lg' | 'block' = 'md';

--- a/src/lib/card/card.component.ts
+++ b/src/lib/card/card.component.ts
@@ -1,9 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
     selector: 'plex-card',
     template: `
-    <div class="card bg-{{ type }}" [ngClass]="{'text-white' : type != 'default'}" [class.selected]="selected">
+    <div #cardColor class="card bg-{{ type }}" [ngClass]="{'text-white' : type != 'default'}" [class.selected]="selected">
         <ng-content select="img"></ng-content>
         <ng-content select="plex-icon"></ng-content>
         <div class="d-flex" [ngClass]="cssAlign">
@@ -26,7 +26,10 @@ export class PlexCardComponent {
     @Input() selected = false;
     @Input() align: 'start' | 'end' | 'center' = 'center';
     @Input() size: 'xs' | 'md' | 'lg' | 'block' = 'md';
-    @Input() type: 'success' | 'warning' | 'danger' | 'dark' | 'default' = 'default';
+    @Input() type: 'success' | 'warning' | 'danger' | 'dark' | 'custom' | 'default' = 'default';
+    @Input() color: string;
+
+    @ViewChild('cardColor', { static: true }) cardColor: ElementRef;
 
     constructor() {
     }
@@ -36,6 +39,12 @@ export class PlexCardComponent {
             return 'justify-content-center';
         } else {
             return this.align === 'start' ? 'justify-content-start' : 'justify-content-end';
+        }
+    }
+
+    ngOnChanges() {
+        if (this.color && this.color.length > 0) {
+            this.cardColor.nativeElement.style.setProperty('--card-color', this.color);
         }
     }
 }

--- a/src/lib/css/classes.scss
+++ b/src/lib/css/classes.scss
@@ -35,3 +35,11 @@
     text-transform: capitalize !important;
   }
 }
+
+.disabled {
+    pointer-events: none!important;
+    user-select: none!important;
+    opacity: .5!important;
+    filter: grayscale(100%)!important;
+    cursor: not-allowed!important;
+}

--- a/src/lib/css/plex-card.scss
+++ b/src/lib/css/plex-card.scss
@@ -27,45 +27,61 @@ plex-card {
         background-color: var(--color-baseDark)!important;
         color: var(--color-tipo)!important;
         box-shadow: inset 0 0 0 3px var(--color-baseDarker)!important;
+    }
+    
+    //Custom color
+    >div.card {
+        &.bg-custom {
+            @include cardBackground;
+            background-color: var(--card-color);
+            --color-tipo: white;
+            --color-base: var(--card-color);
+            --color-baseLight: white;
+            --color-baseDark: var(--card-color);
+            
+            &:hover, &.selected {
+                box-shadow: inset 0 0 0 3px $blue!important;                            
+                filter: brightness(0.85);
+            }
+            }
         }
     
-    // Default
-    > div.bg-default {
-    --color-base: white;
-    --color-tipo: #002738;
-    --color-baseDark: #edf8fd;
-    --color-baseDarker: #00a8e0;
-    }
-
-    // Dark
-    > div.bg-dark {
-        --color-base: #002738;
-        --color-tipo: white;
-        --color-baseDark: #00202e;
+        // Default
+        > div.bg-default {
+        --color-base: white;
+        --color-tipo: #002738;
+        --color-baseDark: #edf8fd;
         --color-baseDarker: #00a8e0;
-    }
+        }
 
-    // Success
-    > div.bg-success {
-        @include cardBackground;
-        --color-baseLight: #c7e79c;
-        --color-base: #8cc63f;
-        --color-tipo: white;
-        --color-baseDark: #70a728;
-        --color-baseDarker: #55801e;
-    }
+        // Dark
+        > div.bg-dark {
+            --color-base: #002738;
+            --color-tipo: white;
+            --color-baseDark: #00202e;
+            --color-baseDarker: #00a8e0;
+        }
 
-    // Warning
-    > div.bg-warning {
-        @include cardBackground;
+        // Success
+        > div.bg-success {
+            @include cardBackground;
+            --color-baseLight: #c7e79c;
+            --color-base: #8cc63f;
+            --color-tipo: white;
+            --color-baseDark: #70a728;
+            --color-baseDarker: #55801e;
+        }
+
+        // Warning
+        > div.bg-warning {
+            @include cardBackground;
             --color-baseLight: #fdc189;
             --color-base: #ff8d22;
             --color-tipo: white;
             --color-baseDark: #e47814;
             --color-baseDarker: #c55f00;
- 
         }
-    
+
         // Danger
         > div.bg-danger {
             @include cardBackground;
@@ -74,7 +90,6 @@ plex-card {
             --color-tipo: white;
             --color-baseDark: #b9311f;
             --color-baseDarker: #a12514;
- 
         }
 
         // Info

--- a/src/lib/css/plex-grid.scss
+++ b/src/lib/css/plex-grid.scss
@@ -59,6 +59,30 @@ plex-grid {
             grid-template-columns: repeat(6, 1fr)!important;
     }
 
+    &[cols="7"] {
+            grid-template-columns: repeat(7, 1fr)!important;	
+    }
+
+    &[cols="8"] {
+            grid-template-columns: repeat(8, 1fr)!important;	
+    }
+
+    &[cols="9"] {
+            grid-template-columns: repeat(9, 1fr)!important;
+    }
+
+    &[cols="10"] {
+            grid-template-columns: repeat(10, 1fr)!important;	
+    }
+
+    &[cols="11"] {
+            grid-template-columns: repeat(11, 1fr)!important;
+    }
+
+    &[cols="12"] {
+            grid-template-columns: repeat(12, 1fr)!important;
+    }
+
     // sizes
     &[size=xs] {	
         --colSize: 2.5rem;
@@ -91,7 +115,6 @@ plex-grid {
     }
 } 
 
-
 // directiva span
 .grid-column-auto {
     grid-column: auto;
@@ -110,6 +133,24 @@ plex-grid {
 }
 .grid-column-span-6 {
     grid-column: span 6;
+}
+.grid-column-span-7 {
+    grid-column: span 7;
+}
+.grid-column-span-8 {
+    grid-column: span 8;
+}
+.grid-column-span-9 {
+    grid-column: span 9;
+}
+.grid-column-span-10 {
+    grid-column: span 10;
+}
+.grid-column-span-11 {
+    grid-column: span 11;
+}
+.grid-column-span-12 {
+    grid-column: span 12;
 }
 .grid-column-span-full {
     grid-column: 100%;

--- a/src/lib/directives/span.directive.ts
+++ b/src/lib/directives/span.directive.ts
@@ -5,7 +5,7 @@ import { Directive, Input, HostBinding } from '@angular/core';
     selector: '[span]'
 })
 export class SpanDirective {
-    @Input() span: 'auto' | '1' | '2' | '3' | '4' | 'full' = 'auto';
+    @Input() span: 'auto' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | 'full' = 'auto';
 
     @HostBinding('class.grid-column-full') get full() {
         return this.span === 'full';
@@ -29,5 +29,37 @@ export class SpanDirective {
 
     @HostBinding('class.grid-column-span-4') get span4() {
         return this.span === '4';
+    }
+
+    @HostBinding('class.grid-column-span-5') get span5() {
+        return this.span === '5';
+    }
+
+    @HostBinding('class.grid-column-span-6') get span6() {
+        return this.span === '6';
+    }
+
+    @HostBinding('class.grid-column-span-7') get span7() {
+        return this.span === '7';
+    }
+
+    @HostBinding('class.grid-column-span-8') get span8() {
+        return this.span === '8';
+    }
+
+    @HostBinding('class.grid-column-span-9') get span9() {
+        return this.span === '9';
+    }
+
+    @HostBinding('class.grid-column-span-10') get span10() {
+        return this.span === '10';
+    }
+
+    @HostBinding('class.grid-column-span-11') get span11() {
+        return this.span === '11';
+    }
+
+    @HostBinding('class.grid-column-span-12') get span12() {
+        return this.span === '12';
     }
 }


### PR DESCRIPTION
- Se extiende encolumnado a 12 columnas (grid-template-columns).
- Se extienden valores de directiva Span a 12 (grid-column).

**Caso de uso**
División interna de paneles del layout.