### PR TITLE
fix(plex-phone): evita mostrar "undefined" si model (aun) no existe

### DIFF
--- a/src/demo/app/phone/phone.component.ts
+++ b/src/demo/app/phone/phone.component.ts
@@ -7,10 +7,15 @@ export class PhoneDemoComponent implements OnInit {
     public model1: any;
     public model2: any;
     public tModel: any;
+    public modeloDinamico: any = {};
 
     ngOnInit() {
         this.tModel = { valor: null };
         this.model1 = { valor: null };
         this.model2 = { valor: null };
+    }
+
+    setModel() {
+        this.modeloDinamico = { valor: null };
     }
 }

--- a/src/demo/app/phone/phone.html
+++ b/src/demo/app/phone/phone.html
@@ -56,5 +56,18 @@
                 <pre>{{tModel | json}}</pre>
             </div>
         </div>
+        <div class="row">
+            <div class="col-md-6">
+                <form>
+                    <plex-phone label="Modelo dinámico" [(ngModel)]="modeloDinamico.valor" required="true"
+                                placeholder="Ej: 2990000000" name="dinamico"></plex-phone>
+                    <plex-button type="info" size="sm" label="Setear modelo" (click)="setModel()"></plex-button>
+                </form>
+            </div>
+            <div class="col-md-6" *ngIf="model1">
+                <label>Modelo</label>
+                <pre>{{modeloDinamico | json}}</pre>
+            </div>
+        </div>
     </plex-layout-main>
 </plex-layout>

--- a/src/lib/phone/phone.component.ts
+++ b/src/lib/phone/phone.component.ts
@@ -99,7 +99,7 @@ export class PlexPhoneComponent implements OnInit, AfterViewInit, ControlValueAc
 
     // Actualización Modelo -> Vista
     writeValue(value: any) {
-        this.renderer.setProperty(this.ref.nativeElement, 'value', value);
+        this.renderer.setProperty(this.ref.nativeElement, 'value', typeof value === 'undefined' ? '' : value);
     }
 
     public hasDanger() {


### PR DESCRIPTION
A veces se necesita crear modelos dinamicamente, para lo cual es necesario que los componentes estén atentos a esta situación, no generando mensajes inesperados o errores.