### PR TITLE
fix(plex-visualizador): corrige posicion flechas prev/next

### DIFF
--- a/src/lib/css/plex-visualizador.scss
+++ b/src/lib/css/plex-visualizador.scss
@@ -22,8 +22,8 @@ plex-visualizador {
         left: 0;
         background: rgba(0, 0, 0, 0.8);
         display: flex;
-        align-items: center;
-        justify-content: center;
+        place-items: center;
+        padding: 0 2rem;
     }
     
     .lightbox img {

--- a/src/lib/visualizador/visualizador.component.ts
+++ b/src/lib/visualizador/visualizador.component.ts
@@ -11,7 +11,7 @@ export type PlexVisualizadorItem = FileObject | string;
 @Component({
     selector: 'plex-visualizador',
     template: `
-    <div *ngIf="opened" class="lightbox hover" (click)="close()">
+    <div *ngIf="opened" class="lightbox hover" (click)="close()" justify>
         <plex-icon (click)="previous();$event.stopPropagation();" type="info" size="xl" name="chevron-double-left" class="parpadeo"></plex-icon>
 
 


### PR DESCRIPTION
**Problema**
Las flechas para navegar entre las imágenes del lightbox se encuentran relativas a la imagen maximizada, generando que su ubicación varíe según el ancho de la imagen.

**Solución**
Se agrega la directiva 'justify' para distribuir de manera uniforme las flechas y la imagen.
Adicionalmente, se agrega padding al lightbox para evitar que la navegación quede en los extremos de la pantalla.