### PR TITLE
feat(plex-grid): refactoriza y extiende componente

### DIFF
--- a/src/demo/app/grid/grid.component.html
+++ b/src/demo/app/grid/grid.component.html
@@ -1,53 +1,98 @@
-<plex-layout main="8">
+<plex-layout main="8" resizable="true" min="4" max="8" [steps]="2">
     <plex-layout-main>
-        <plex-title titulo="plex-grid"></plex-title>
-        <h6>Plex-grid es un envolvente que tiene como objetivo organizar y distribuir elementos en una reticula</h6>
-        <plex-title titulo="atributo 'cols' (columnas fijas) | cols= '2' | '3' | '4' | '5' | '6'" size="md">
+        <plex-title main titulo="plex-grid">
+            <plex-wrapper>
+                <h6>Plex-grid es un envolvente que tiene como objetivo organizar y distribuir elementos en una reticula
+                </h6>
+            </plex-wrapper>
         </plex-title>
-        <plex-grid type="auto" size="md" cols="2">
-            <plex-card direction="column" type="info" align="center" *ngFor="let dato of datos | slice:1:3">
-                <plex-label titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
-                </plex-label>
-            </plex-card>
+        <!-- Sizes -->
+        <plex-grid cols="2" size="auto">
+            <div>
+                <section>
+                    <plex-title titulo="size='xs'" size="sm"></plex-title>
+                    <plex-grid type="auto" size="xs">
+                        <plex-card direction="column" type="custom" color="{{ dato.color }}" align="center"
+                                   *ngFor="let dato of datos | slice:0:1">
+                            <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                            </plex-label>
+                        </plex-card>
+                    </plex-grid>
+                </section>
+                <section>
+                    <plex-title titulo="size='sm'" size="sm"></plex-title>
+                    <plex-grid type="auto" size="sm">
+                        <plex-card direction="column" type="custom" color="{{ dato.color }}" align="center"
+                                   *ngFor="let dato of datos | slice:1:2">
+                            <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                            </plex-label>
+                        </plex-card>
+                    </plex-grid>
+                </section>
+                <section>
+                    <plex-title titulo="size='md'" size="sm"></plex-title>
+                    <plex-grid type="auto" size="md">
+                        <plex-card direction="column" type="custom" color="{{ dato.color }}" align="center"
+                                   *ngFor="let dato of datos | slice:2:3">
+                            <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                            </plex-label>
+                        </plex-card>
+                    </plex-grid>
+                </section>
+            </div>
+            <div>
+                <section>
+                    <plex-title titulo="size='lg'" size="sm"></plex-title>
+                    <plex-grid type="auto" size="lg">
+                        <plex-card direction="column" type="custom" color="{{ dato.color }}" align="center"
+                                   *ngFor="let dato of datos | slice:3:4">
+                            <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                            </plex-label>
+                        </plex-card>
+                    </plex-grid>
+                </section>
+                <section>
+                    <plex-title titulo="size='xl'" size="sm"></plex-title>
+                    <plex-grid type="auto" size="xl">
+                        <plex-card direction="column" type="custom" color="{{ dato.color }}" align="center"
+                                   *ngFor="let dato of datos | slice:4:5">
+                            <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                            </plex-label>
+                        </plex-card>
+                    </plex-grid>
+                </section>
+            </div>
         </plex-grid>
-        <plex-grid type="auto" size="md" cols="3">
-            <plex-card direction="column" type="info" align="center" *ngFor="let dato of datos | slice:2:5">
-                <plex-label titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
-                </plex-label>
-            </plex-card>
-        </plex-grid>
-        <plex-grid cols="2">
-            <section>
-                <plex-title titulo="plex-grid size='xs'" size="sm"></plex-title>
-                <plex-grid type="full" size="xs">
-                    <img *ngFor="let img of img" src="{{ img.url }}" alt="">
-                </plex-grid>
-                <plex-title titulo="plex-grid size='sm'" size="sm"></plex-title>
-                <plex-grid type="full" size="sm">
-                    <img *ngFor="let img of img  | slice:2:5" src="{{ img.url }}" alt="">
-                </plex-grid>
-                <plex-title titulo="plex-grid size='md'" size="sm"></plex-title>
-                <plex-grid type="full" size="md">
-                    <img *ngFor="let img of img | slice:1:4" src="{{ img.url }}" alt="">
+        <div>
+            <!-- Encolumnado manual -->
+            <section class="mt-4">
+                <plex-title titulo="Encolumnado manual: colsSm | colsMd | colsLg (expandir sidebar!)" size="sm">
+                </plex-title>
+                <plex-grid responsive type="full" size="md" cols="3" colsSm="1" colsMd="2" colsLg="3">
+                    <plex-card direction="column" type="info" align="center" *ngFor="let dato of datos | slice:0:3">
+                        <plex-label size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
+                        </plex-label>
+                    </plex-card>
                 </plex-grid>
             </section>
-            <section>
-                <plex-title titulo="plex-grid size='lg'" size="sm"></plex-title>
-                <plex-grid type="full" size="lg">
-                    <img *ngFor="let img of img | slice:0:2" src="{{ img.url }}" alt="">
+            <!-- Columnas fijas -->
+            <section class="mt-4">
+                <plex-title titulo="atributo 'cols' (columnas fijas) | cols= '2' | ... | '12'" size="sm">
+                </plex-title>
+                <plex-grid type="auto" size="md" cols="2">
+                    <plex-card direction="column" type="info" align="center" *ngFor="let dato of datos | slice:0:2">
+                        <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                        </plex-label>
+                    </plex-card>
                 </plex-grid>
-                <plex-title titulo="plex-grid [noGap] (grilla sin espacios)" size="sm"></plex-title>
-                <plex-grid noGap type="full" size="md">
-                    <img *ngFor="let img of img | slice:1:3" src="{{ img.url }}" alt="">
+                <plex-grid type="auto" size="md" cols="3">
+                    <plex-card direction="column" type="info" align="center" *ngFor="let dato of datos | slice:2:5">
+                        <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                        </plex-label>
+                    </plex-card>
                 </plex-grid>
             </section>
-            <section span="2">
-                <plex-title titulo="plex-grid size='xl'" size="sm"></plex-title>
-                <plex-grid type="full" size="xl">
-                    <img *ngFor="let img of img | slice:3:5" src="{{ img.url }}" alt="">
-                </plex-grid>
-            </section>
-        </plex-grid>
+        </div>
     </plex-layout-main>
 
     <!-- Sidebar -->
@@ -56,35 +101,48 @@
         <plex-title titulo="plex-grid type='full'" size="sm"></plex-title>
         <h6>La propiedad 'full' genera que las celdas que integran la grilla ocupen todo el espacio disponible.</h6>
         <plex-grid type="full" size="sm">
-            <img *ngFor="let img of img | slice:0:4" src="{{ img.url }}" alt="">
+            <plex-card direction="column" type="warning" align="center" *ngFor="let dato of datos | slice:0:3">
+                <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                </plex-label>
+            </plex-card>
         </plex-grid>
         <plex-title titulo="plex-grid type='auto'" size="sm"></plex-title>
         <h6>La propiedad 'auto' implica que las celdas que componen la grilla mantengan su aspecto original.</h6>
         <plex-grid type="auto" size="sm">
-            <img *ngFor="let img of img | slice:0:3" src="{{ img.url }}" alt="">
+            <plex-card direction="column" type="warning" align="center" *ngFor="let dato of datos | slice:0:3">
+                <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                </plex-label>
+            </plex-card>
         </plex-grid>
+        <!-- plex-labels engrillados -->
         <plex-title titulo="plex-grid utilizado con labels" size="sm"></plex-title>
         <plex-grid type="full" size="sm">
-            <div *ngFor="let dato of datos | slice:0:3">
-                <plex-label titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
-                </plex-label>
-            </div>
+            <plex-label size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
+                        *ngFor="let dato of datos | slice:0:3">
+            </plex-label>
         </plex-grid>
-        <plex-title titulo="Directiva span = '2' | '3' | '4' | '5' | '6'" size="sm"></plex-title>
+        <!-- Directiva span -->
+        <plex-title titulo="Directiva span = '2' | ... | '12'" size="sm"></plex-title>
         <h6>Es aplicable a los elementos que integran el plex-grid. El valor asignado determina la cantidad de columnas
             que ocupa el elemento.</h6>
-        <plex-grid type="auto" size="md">
-            <img span=2
-                 src="https://images.unsplash.com/photo-1560582861-45078880e48e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&full=crop&w=500&q=60"
-                 alt="">
-            <img src="https://images.unsplash.com/photo-1579684385127-1ef15d508118?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&full=crop&w=500&q=60"
-                 alt="">
-            <img src="https://images.unsplash.com/photo-1505751172876-fa1923c5c528?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&full=crop&w=500&q=60"
-                 alt="">
-            <img src="https://images.unsplash.com/photo-1560582861-45078880e48e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&full=crop&w=500&q=60"
-                 alt="">
-            <img src="https://images.unsplash.com/photo-1550831107-1553da8c8464?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&full=crop&w=500&q=60"
-                 alt="">
+        <plex-grid cols="3" size="md" *ngFor="let dato of datos | slice:0:1">
+            <plex-card span="2" direction="column" type="custom" color="{{ dato.color }}" align="center">
+                <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                </plex-label>
+            </plex-card>
+            <plex-card direction="column" type="info" align="center">
+                <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                </plex-label>
+            </plex-card>
+        </plex-grid>
+        <!-- sin calles -->
+        <plex-title titulo="plex-grid [noGap] (grilla sin espacios)" size="sm"></plex-title>
+        <plex-grid gap="true" type="auto" size="md">
+            <plex-card direction="column" type="custom" color="{{ dato.color }}" align="center"
+                       *ngFor="let dato of datos | slice:0:3">
+                <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
+                </plex-label>
+            </plex-card>
         </plex-grid>
     </plex-layout-sidebar>
 </plex-layout>

--- a/src/demo/app/grid/grid.component.ts
+++ b/src/demo/app/grid/grid.component.ts
@@ -5,35 +5,14 @@ import { Component, OnInit } from '@angular/core';
 })
 export class GridDemoComponent {
 
-    img = [
-        {
-            url: 'https://images.unsplash.com/photo-1560582861-45078880e48e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60',
-        },
-        {
-            url: 'https://images.unsplash.com/photo-1579684385127-1ef15d508118?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60',
-        },
-        {
-            url: 'https://images.unsplash.com/photo-1505751172876-fa1923c5c528?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60',
-        },
-        {
-            url: 'https://images.unsplash.com/photo-1550831107-1553da8c8464?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60',
-        },
-        {
-            url: 'https://images.unsplash.com/photo-1527613426441-4da17471b66d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60',
-        },
-        {
-            url: 'https://images.unsplash.com/photo-1530497610245-94d3c16cda28?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60',
-        },
-    ];
-
     datos = [
-        { label: 'edad', valor: '41 años', type: 'success' },
-        { label: 'documento', valor: '29.879.253', type: 'info' },
-        { label: 'sexo', valor: 'Masculino', type: 'default' },
-        { label: 'efector', valor: 'Hospital Provincial de Neuquen Castro Rendon', type: 'warning' },
-        { label: 'fecha de nacimiento', valor: '14 de Julio de 1953', type: 'success' },
-        { label: 'CUIL', valor: '20-16879253-5', type: 'warning' },
-        { label: 'nota', valor: 'Donec quam felis, ultricies nec, pellentesque eu, pretium quis. Lorem ipsum sonnet.', type: 'warning' },
-        { label: 'Comience buscando un paciente en la barra superior', valor: 'Ingrese al menos tres caracteres. Si la búsqueda no arroja el resultado esperado, presione el botón "Paciente Nuevo"', type: 'warning' }
+        { label: '1', valor: 'mobile: una columna (todo el ancho)', type: 'success', color: '#00bcb4' },
+        { label: '2', valor: 'tablet: grilla de dos columnas', type: 'info', color: '#EA1E79' },
+        { label: '3', valor: 'desktop: grilla de tres columnas', type: 'default', color: '#92278e' },
+        { label: '4', valor: 'texto secundario', type: 'warning', color: '#062837' },
+        { label: '5', valor: 'texto secundario', type: 'success', color: '#0070cc' },
+        { label: '6', valor: 'texto secundario', type: 'warning', color: '#66DFFF' },
+        { label: '7', valor: 'texto secundario', type: 'warning', color: '#a0a0a0' },
+        { label: '8', valor: 'texto secundario', type: 'warning', color: '#b9c512' }
     ];
 }

--- a/src/lib/css/plex-grid.scss
+++ b/src/lib/css/plex-grid.scss
@@ -6,7 +6,6 @@ plex-grid {
         flex: 1 20em;	
         align-self: center;	
         margin-top: .5rem;	
-        text-transform: capitalize;
         grid-template-columns: repeat(var(--type), minmax(var(--colSize), 1fr));	
         grid-gap: .5rem;
     
@@ -40,51 +39,16 @@ plex-grid {
         }
     
         // columnas fijas
-        &.cols-2 {
-                grid-template-columns: repeat(2, 1fr)!important;	
+        $columns: 1 2 3 4 5 6 7 8 9 10 11 12;
+
+        @each $col in $columns {
+            $i: index($columns, $col);
+            &.cols-#{$col} { 
+                grid-template-columns: repeat($i, 1fr);	
+            }
         }
-    
-        &.cols-3 {
-                grid-template-columns: repeat(3, 1fr)!important;	
-        }
-    
-        &.cols-4 {
-                grid-template-columns: repeat(4, 1fr)!important;
-        }
-    
-        &.cols-5 {
-                grid-template-columns: repeat(5, 1fr)!important;	
-        }
-    
-        &.cols-6 {
-                grid-template-columns: repeat(6, 1fr)!important;
-        }
-    
-        &.cols-7 {
-                grid-template-columns: repeat(7, 1fr)!important;	
-        }
-    
-        &.cols-8 {
-                grid-template-columns: repeat(8, 1fr)!important;	
-        }
-    
-        &.cols-9 {
-                grid-template-columns: repeat(9, 1fr)!important;
-        }
-    
-        &.cols-10 {
-                grid-template-columns: repeat(10, 1fr)!important;	
-        }
-    
-        &.cols-11 {
-                grid-template-columns: repeat(11, 1fr)!important;
-        }
-    
-        &.cols-12 {
-                grid-template-columns: repeat(12, 1fr)!important;
-        }
-    
-        // sizes
+                 
+        // sizes 
         &.size-xs {	
             --colSize: 2.5rem;
             --rowSize: 2.5rem;
@@ -119,46 +83,53 @@ plex-grid {
         &[noGap] {
             grid-gap: 0!important;
         }
-    }
-} 
 
-// directiva span
-.grid-column-auto {
-    grid-column: auto;
+        // Encolumnado responsive manual
+        &.size-sm {
+
+            @each $col in $columns {
+                $i: index($columns, $col);
+                &.cols-sm-#{$col} { 
+                    grid-template-columns: repeat($i, 1fr)!important;	
+                }
+            }
+        }
+
+        &.size-md {
+
+            @each $col in $columns {
+                $i: index($columns, $col);
+                &.cols-md-#{$col} { 
+                    grid-template-columns: repeat($i, 1fr)!important;	
+                }
+            }
+        }
+
+        &.size-lg {
+
+            @each $col in $columns {
+                $i: index($columns, $col);
+                &.cols-lg-#{$col} { 
+                    grid-template-columns: repeat($i, 1fr)!important;	
+                }
+            }
+        }
+
+    }
 }
-.grid-column-span-2 {
-    grid-column: span 2;
-}
-.grid-column-span-3 {
-    grid-column: span 3;
-}
-.grid-column-span-4 {
-    grid-column: span 4;
-}
-.grid-column-span-5 {
-    grid-column: span 5;
-}
-.grid-column-span-6 {
-    grid-column: span 6;
-}
-.grid-column-span-7 {
-    grid-column: span 7;
-}
-.grid-column-span-8 {
-    grid-column: span 8;
-}
-.grid-column-span-9 {
-    grid-column: span 9;
-}
-.grid-column-span-10 {
-    grid-column: span 10;
-}
-.grid-column-span-11 {
-    grid-column: span 11;
-}
-.grid-column-span-12 {
-    grid-column: span 12;
-}
-.grid-column-span-full {
-    grid-column: 100%;
-}
+    // directiva span
+    $columns: 1 2 3 4 5 6 7 8 9 10 11 12;
+
+    @each $span in $columns {
+    $i: index($columns, $span);
+        .grid-column-span-#{$span} { 
+        grid-column: span $i;
+        }       
+        .grid-column-auto {
+            grid-column: auto;
+        }
+        .grid-column-full {
+            grid-column: 100%;
+        }
+    }
+

--- a/src/lib/css/plex-grid.scss
+++ b/src/lib/css/plex-grid.scss
@@ -1,117 +1,124 @@
-plex-grid {	
-    display: grid;	
-    grid-gap: .5rem;	
-    grid-auto-flow: dense; 	
-    flex: 1 20em;	
-    align-self: center;	
-    margin-top: .5rem;	
-    text-transform: capitalize;
-    grid-template-columns: repeat(var(--type), minmax(var(--colSize), 1fr));	
-    grid-gap: .5rem;
-
-    plex-card {
-        img {
-            object-fit: contain!important;
-            max-height: var(--rowSize);
+plex-grid {
+   > section {
+        display: grid;	
+        grid-gap: .5rem;	
+        grid-auto-flow: dense; 	
+        flex: 1 20em;	
+        align-self: center;	
+        margin-top: .5rem;	
+        text-transform: capitalize;
+        grid-template-columns: repeat(var(--type), minmax(var(--colSize), 1fr));	
+        grid-gap: .5rem;
+    
+        plex-card {
+            img {
+                object-fit: contain!important;
+                max-height: var(--rowSize);
+            }
         }
-    }
-
-    // labels 
-    span {	
-        white-space: wrap;	
-        text-overflow: ellipsis;	
-        overflow: hidden;	
-    }	
-
-    img {
-        object-fit: cover;
-        width: 100%;
-        height: var(--colSize);
-    }
     
-    // types
-    &[type=full] {
-        --type: auto-fit;
-    }
+        // labels 
+        span {	
+            white-space: wrap;	
+            text-overflow: ellipsis;	
+            overflow: hidden;	
+        }	
     
-    &[type=auto] {
-        --type: auto-fill;
-    }
-
-    // columnas fijas
-    &[cols="2"] {
-            grid-template-columns: repeat(2, 1fr)!important;	
-    }
-
-    &[cols="3"] {
-            grid-template-columns: repeat(3, 1fr)!important;	
-    }
-
-    &[cols="4"] {
-            grid-template-columns: repeat(4, 1fr)!important;
-    }
-
-    &[cols="5"] {
-            grid-template-columns: repeat(5, 1fr)!important;	
-    }
-
-    &[cols="6"] {
-            grid-template-columns: repeat(6, 1fr)!important;
-    }
-
-    &[cols="7"] {
-            grid-template-columns: repeat(7, 1fr)!important;	
-    }
-
-    &[cols="8"] {
-            grid-template-columns: repeat(8, 1fr)!important;	
-    }
-
-    &[cols="9"] {
-            grid-template-columns: repeat(9, 1fr)!important;
-    }
-
-    &[cols="10"] {
-            grid-template-columns: repeat(10, 1fr)!important;	
-    }
-
-    &[cols="11"] {
-            grid-template-columns: repeat(11, 1fr)!important;
-    }
-
-    &[cols="12"] {
-            grid-template-columns: repeat(12, 1fr)!important;
-    }
-
-    // sizes
-    &[size=xs] {	
-        --colSize: 2.5rem;
-        --rowSize: 2.5rem;
-    }
+        img {
+            object-fit: cover;
+            width: 100%;
+            height: var(--colSize);
+        }
+        
+        // types
+        &.type-full {
+            --type: auto-fit;
+        }
+        
+        &.type-auto {
+            --type: auto-fill;
+        }
     
-    &[size=sm] {	
-        --colSize: 5rem;
-        --rowSize: 5rem;
-    }	
+        // columnas fijas
+        &.cols-2 {
+                grid-template-columns: repeat(2, 1fr)!important;	
+        }
     
-    &[size=md] {
-        --colSize: 7.5rem;
-        --rowSize: 7.5rem;
-    }
+        &.cols-3 {
+                grid-template-columns: repeat(3, 1fr)!important;	
+        }
     
-    &[size=lg] {
-        --colSize: 10rem;
-        --rowSize: 10rem;
-    }
+        &.cols-4 {
+                grid-template-columns: repeat(4, 1fr)!important;
+        }
     
-    &[size=xl] {	
-        --colSize: 15rem;
-        --rowSize: 15rem;
-    }	
-
-    // gaps
-    &[noGap] {
-        grid-gap: 0!important;
+        &.cols-5 {
+                grid-template-columns: repeat(5, 1fr)!important;	
+        }
+    
+        &.cols-6 {
+                grid-template-columns: repeat(6, 1fr)!important;
+        }
+    
+        &.cols-7 {
+                grid-template-columns: repeat(7, 1fr)!important;	
+        }
+    
+        &.cols-8 {
+                grid-template-columns: repeat(8, 1fr)!important;	
+        }
+    
+        &.cols-9 {
+                grid-template-columns: repeat(9, 1fr)!important;
+        }
+    
+        &.cols-10 {
+                grid-template-columns: repeat(10, 1fr)!important;	
+        }
+    
+        &.cols-11 {
+                grid-template-columns: repeat(11, 1fr)!important;
+        }
+    
+        &.cols-12 {
+                grid-template-columns: repeat(12, 1fr)!important;
+        }
+    
+        // sizes
+        &.size-xs {	
+            --colSize: 2.5rem;
+            --rowSize: 2.5rem;
+        }
+        
+        &.size-sm {	
+            --colSize: 5rem;
+            --rowSize: 5rem;
+        }	
+        
+        &.size-md {
+            --colSize: 7.5rem;
+            --rowSize: 7.5rem;
+        }
+        
+        &.size-lg {
+            --colSize: 10rem;
+            --rowSize: 10rem;
+        }
+        
+        &.size-xl {	
+            --colSize: 15rem;
+            --rowSize: 15rem;
+        }	
+        
+        &.size-auto {	
+            --colSize: auto;
+            --rowSize: auto;
+        }	
+    
+        // gaps
+        &[noGap] {
+            grid-gap: 0!important;
+        }
     }
 } 
 

--- a/src/lib/css/plex-grid.scss
+++ b/src/lib/css/plex-grid.scss
@@ -1,5 +1,4 @@
 plex-grid {
-   > section {
         display: grid;	
         grid-gap: .5rem;	
         grid-auto-flow: dense; 	
@@ -30,11 +29,11 @@ plex-grid {
         }
         
         // types
-        &.type-full {
+        &[type=full] {
             --type: auto-fit;
         }
         
-        &.type-auto {
+        &[type=auto] {
             --type: auto-fill;
         }
     
@@ -43,38 +42,38 @@ plex-grid {
 
         @each $col in $columns {
             $i: index($columns, $col);
-            &.cols-#{$col} { 
+            &[cols="#{$col}"] { 
                 grid-template-columns: repeat($i, 1fr);	
             }
         }
                  
         // sizes 
-        &.size-xs {	
+        &[size=xs] {	
             --colSize: 2.5rem;
             --rowSize: 2.5rem;
         }
         
-        &.size-sm {	
+        &[size=sm] {	
             --colSize: 5rem;
             --rowSize: 5rem;
         }	
         
-        &.size-md {
+        &[size=md] {
             --colSize: 7.5rem;
             --rowSize: 7.5rem;
         }
         
-        &.size-lg {
+        &[size=lg] {
             --colSize: 10rem;
             --rowSize: 10rem;
         }
         
-        &.size-xl {	
+        &[size=xl] {	
             --colSize: 15rem;
             --rowSize: 15rem;
         }	
         
-        &.size-auto {	
+        &[size=auto] {	
             --colSize: auto;
             --rowSize: auto;
         }	
@@ -84,52 +83,48 @@ plex-grid {
             grid-gap: 0!important;
         }
 
+        // Directiva span
+        $columns: 1 2 3 4 5 6 7 8 9 10 11 12;
+    
+        @each $span in $columns {
+        $i: index($columns, $span);
+            [span="#{$span}"] { 
+            grid-column: span $i;
+            }       
+            [span=auto] {
+                grid-column: auto;
+            }
+            [span=full] {
+                grid-column: 100%;
+            }
+        }
+        
         // Encolumnado responsive manual
         &.size-sm {
-
             @each $col in $columns {
                 $i: index($columns, $col);
-                &.cols-sm-#{$col} { 
+                &[colsSm="#{$col}"] { 
                     grid-template-columns: repeat($i, 1fr)!important;	
                 }
             }
         }
 
         &.size-md {
-
             @each $col in $columns {
                 $i: index($columns, $col);
-                &.cols-md-#{$col} { 
+                &[colsMd="#{$col}"] { 
                     grid-template-columns: repeat($i, 1fr)!important;	
                 }
             }
         }
 
         &.size-lg {
-
             @each $col in $columns {
                 $i: index($columns, $col);
-                &.cols-lg-#{$col} { 
+                &[colsLg="#{$col}"] { 
                     grid-template-columns: repeat($i, 1fr)!important;	
                 }
             }
         }
-
     }
-}
-    // directiva span
-    $columns: 1 2 3 4 5 6 7 8 9 10 11 12;
-
-    @each $span in $columns {
-    $i: index($columns, $span);
-        .grid-column-span-#{$span} { 
-        grid-column: span $i;
-        }       
-        .grid-column-auto {
-            grid-column: auto;
-        }
-        .grid-column-full {
-            grid-column: 100%;
-        }
-    }
-
+    

--- a/src/lib/grid/grid.component.ts
+++ b/src/lib/grid/grid.component.ts
@@ -4,7 +4,7 @@ import { PlexLabelComponent } from '../label/label.component';
 @Component({
     selector: 'plex-grid',
     template: `
-            <section class="cols-{{ cols }} grid-column-span-{{ span }} size-{{ size }} type-{{ type }}" responsive>
+            <section responsive class="cols-{{ cols }} size-{{ size }} type-{{ type }} cols-sm-{{ colSm }} cols-md-{{ colMd }} cols-lg-{{ colLg }}">
                <ng-content></ng-content>
             </section>
     `,
@@ -16,8 +16,6 @@ export class PlexGridComponent implements AfterViewChecked {
     @Input() size: 'auto' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'auto';
 
     @Input() cols: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
-    @Input() span: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
-
 
     @Input() colSm: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
     @Input() colMd: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';

--- a/src/lib/grid/grid.component.ts
+++ b/src/lib/grid/grid.component.ts
@@ -4,21 +4,24 @@ import { PlexLabelComponent } from '../label/label.component';
 @Component({
     selector: 'plex-grid',
     template: `
-            <ng-content></ng-content>
+            <section class="cols-{{ cols }} grid-column-span-{{ span }} size-{{ size }} type-{{ type }}" responsive>
+               <ng-content></ng-content>
+            </section>
     `,
 })
 
 export class PlexGridComponent implements AfterViewChecked {
 
-    /**
-     * Propiedades desde CSS
-     *
-     * type= auto|fill
-     * size= xs|sm|md|lg|xl
-     * cols= 2|3|4|5|6
-     * span= 2|3|4|5|6
-     *
-     */
+    @Input() type: 'auto' | 'full';
+    @Input() size: 'auto' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'auto';
+
+    @Input() cols: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
+    @Input() span: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
+
+
+    @Input() colSm: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
+    @Input() colMd: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
+    @Input() colLg: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
 
     @ContentChildren(PlexLabelComponent) plexLabels: QueryList<PlexLabelComponent>;
     @ContentChildren(PlexLabelComponent, { read: ElementRef }) plexLabelsElement: QueryList<ElementRef>;

--- a/src/lib/grid/grid.component.ts
+++ b/src/lib/grid/grid.component.ts
@@ -4,22 +4,25 @@ import { PlexLabelComponent } from '../label/label.component';
 @Component({
     selector: 'plex-grid',
     template: `
-            <section responsive class="cols-{{ cols }} size-{{ size }} type-{{ type }} cols-sm-{{ colSm }} cols-md-{{ colMd }} cols-lg-{{ colLg }}">
                <ng-content></ng-content>
-            </section>
     `,
 })
 
 export class PlexGridComponent implements AfterViewChecked {
 
-    @Input() type: 'auto' | 'full';
-    @Input() size: 'auto' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'auto';
-
-    @Input() cols: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
-
-    @Input() colSm: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
-    @Input() colMd: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
-    @Input() colLg: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
+    /**
+     * Propiedades desde CSS
+     *
+     * type= auto|full
+     * size= xs|sm|md|lg|xl
+     * cols= 1|2|3|4|5|6|7|8|9|10|11|12
+     * span= 1|2|3|4|5|6|7|8|9|10|11|12
+     * ENCOLUMNADO RESPONSIVE MANUAL(Funciona con directiva RESPONSIVE)
+     * colsSm= 1|2|3|4|5|6|7|8|9|10|11|12
+     * colsMd= 1|2|3|4|5|6|7|8|9|10|11|12
+     * colsLg= 1|2|3|4|5|6|7|8|9|10|11|12
+     *
+     */
 
     @ContentChildren(PlexLabelComponent) plexLabels: QueryList<PlexLabelComponent>;
     @ContentChildren(PlexLabelComponent, { read: ElementRef }) plexLabelsElement: QueryList<ElementRef>;


### PR DESCRIPTION
Task: https://proyectos.andes.gob.ar/browse/PLEX-243

- Se evita herencia indeseada de atributos propios de la grilla (ocurría al anidar una plex-grid dentro de otra plex-grid, si la segunda no tenía seteado un valor en sus atributos, tomaba los del padre).
- Se elimina la clase 'text-transform: capitalize' (actualmente heredada por todos los componentes que aloja la grilla).
- Se agrega la posibilidad de setear la cantidad de columnas dependiendo del breakpoint (colsSm - colsMd - colsLg).
- Se reemplazan clases modificadoras por mixins.
- Se modifica el nombre de la clase 'size' para evitar colisión con clases de directiva [responsive].
- Se declaran los atributos desde el componente (y no desde el css).

**Plus:**
Se actualiza demo del componente
![andes-plex-grid-refactor](https://user-images.githubusercontent.com/5895886/115384839-ddf27280-a1ad-11eb-8aef-d6bc0d950591.PNG)
