### PR TITLE
fix(plex-layout): permite funcionamiento de resizable

### DIFF
--- a/src/lib/css/layout.scss
+++ b/src/lib/css/layout.scss
@@ -68,7 +68,7 @@ plex-layout {
 
     &[resizable="true"] > section {
         > div.row {
-            div[class^="col-"] {
+            > div[class*="col-"] {
                 transition: all 900ms ease;
                 
                 /* Botonera sidebar expandible */


### PR DESCRIPTION
**Problema**
Se utilizaba el selector `[class^="col-"]` por lo que al inyectarse una clase antes de la clase `col-`, el resto de las clases anidadas quedaban sin efecto.

**Solución** 
Se modifica el selector por `[class*="col-"]` preservando las restricciones pertinentes.

**Sugerencia**
Testear en la app apuntando a esta rama