### PR TITLE
feat(plex-card): refactor + tipología outlined

### DIFF
--- a/src/demo/app/card/card.component.html
+++ b/src/demo/app/card/card.component.html
@@ -3,8 +3,21 @@
         <plex-title titulo="plex-card"></plex-title>
         <h5>Una <b>plex-card</b> es una envolvente rectangular que aloja otros micro-componentes tales como: plex-badge,
             plex-label, plex-button (y sus respectivos atributos).</h5>
-        <hr>
-        <plex-grid cols="3">
+        <plex-title titulo="plex-card align=center" size="sm"></plex-title>
+        <plex-grid type="auto" cols="2" size="md">
+            <plex-card align="center" type="default" *ngFor="let agenda of agendas | slice:0:2"
+                       [selected]="agenda.selected" (click)="agenda.selected = !agenda.selected">
+                <plex-badge type="{{ agenda.type }}">{{ agenda.type }}</plex-badge>
+                <plex-badge type="info">{{ agenda.horario }}</plex-badge>
+                <plex-label size="md" direction="column" type="{{ agenda.type }}" titulo="{{ agenda.profesional }}"
+                            subtitulo="{{ agenda.prestacion }}" icon="star">
+                </plex-label>
+                <plex-button type="info" icon="eye" size="sm"></plex-button>
+                <plex-button type="success" icon="plus" size="sm"></plex-button>
+            </plex-card>
+        </plex-grid>
+        <plex-grid type="full" cols="2" size="md">
+            <!-- No seleccionables -->
             <div>
                 <plex-title titulo="plex-card aligned=start" size="sm"></plex-title>
                 <plex-grid type="auto" size="lg">
@@ -65,6 +78,42 @@
                 </plex-grid>
             </div>
         </plex-grid>
+        <!-- Type Dark (invert) -->
+        <plex-grid cols="2">
+            <plex-card selectable="true" class="mt-1" align="center" type="dark" styled="filled"
+                       *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
+                       (click)="dato.selected = !dato.selected">
+                <plex-badge type="warning">badge</plex-badge>
+                <plex-label direction="column" size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
+                            icon="information-variant">
+                </plex-label>
+                <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
+            </plex-card>
+            <plex-card selectable="true" class="mt-1" align="center" styled="outlined" type="dark"
+                       *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
+                       (click)="dato.selected = !dato.selected">
+                <plex-badge type="warning">badge</plex-badge>
+                <plex-label direction="column" size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
+                            icon="information-variant">
+                </plex-label>
+                <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
+            </plex-card>
+        </plex-grid>
+        <div span="2">
+            <!-- Calendario -->
+            <plex-title titulo="plex-card: conjunto de celdas" size="sm"></plex-title>
+            <plex-grid type="auto" size="md" noGap>
+                <plex-card align="center" type="default" *ngFor="let celda of calendario | slice:0:25"
+                           [selected]="celda.selected" (click)="celda.selected = !celda.selected">
+                    <plex-badge type="success">{{ celda.turnos }}</plex-badge>
+                    <plex-badge type="warning">{{ celda.agendas }}</plex-badge>
+                    <plex-label size="lg" titulo="{{ celda.fecha }}" subtitulo="">
+                    </plex-label>
+                    <plex-button type="warning" icon="pencil" size="sm"></plex-button>
+                </plex-card>
+            </plex-grid>
+        </div>
+
     </plex-layout-main>
 
     <!-- Sidebar -->
@@ -79,7 +128,8 @@
                 <plex-label size="md" direction="row" titulo="{{ agenda.horario }}"
                             subtitulo="{{ agenda.profesional }}">
                 </plex-label>
-                <plex-button type="warning" label="modificar" size="sm"></plex-button>
+                <plex-button type="warning" label="modificar" size="sm" [disabled]="agenda.turnos === 'sin turnos'">
+                </plex-button>
             </plex-card>
         </plex-grid>
         <plex-title titulo="plex-card con imagenes" size="sm"></plex-title>

--- a/src/demo/app/card/card.component.html
+++ b/src/demo/app/card/card.component.html
@@ -25,6 +25,15 @@
                         </plex-label>
                         <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
                     </plex-card>
+                    <plex-card selectable="true" span="2" class="mt-1" align="center" styled="filled" type="dark"
+                               *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
+                               (click)="dato.selected = !dato.selected">
+                        <plex-badge type="warning">badge</plex-badge>
+                        <plex-label direction="column" size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
+                                    icon="information-variant">
+                        </plex-label>
+                        <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
+                    </plex-card>
                 </plex-grid>
             </div>
             <div span="2">

--- a/src/demo/app/card/card.component.html
+++ b/src/demo/app/card/card.component.html
@@ -3,9 +3,9 @@
         <plex-title titulo="plex-card"></plex-title>
         <h5>Una <b>plex-card</b> es una envolvente rectangular que aloja otros micro-componentes tales como: plex-badge,
             plex-label, plex-button (y sus respectivos atributos).</h5>
-        <plex-title titulo="plex-card align=center" size="sm"></plex-title>
+        <plex-title titulo="plex-card aligned=center" size="sm"></plex-title>
         <plex-grid type="auto" cols="2" size="md">
-            <plex-card align="center" type="default" *ngFor="let agenda of agendas | slice:0:2"
+            <plex-card aligned="center" type="default" *ngFor="let agenda of agendas | slice:0:2"
                        [selected]="agenda.selected" (click)="agenda.selected = !agenda.selected">
                 <plex-badge type="{{ agenda.type }}">{{ agenda.type }}</plex-badge>
                 <plex-badge type="info">{{ agenda.horario }}</plex-badge>
@@ -19,68 +19,39 @@
         <plex-grid type="full" cols="2" size="md">
             <!-- No seleccionables -->
             <div>
-                <plex-title titulo="plex-card aligned=start" size="sm"></plex-title>
+                <plex-title titulo="plex-card mode=filled (no seleccionables)" size="sm"></plex-title>
                 <plex-grid type="auto" size="lg">
-                    <plex-card [color]="color" aligned="start" type="{{ dato.type }}"
+                    <plex-card selectable="true" [color]="color" align="start" [selected]="dato.selected"
+                               (click)="dato.selected = !dato.selected" type="{{ dato.type }}" mode="{{ dato.style }}"
+                               *ngFor="let dato of datos | slice:0:6">
+                        <plex-badge type="warning">badge</plex-badge>
+                        <plex-label size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
+                        </plex-label>
+                        <plex-button type="warning" label="aceptar"></plex-button>
+                    </plex-card>
+                </plex-grid>
+            </div>
+            <div>
+                <plex-title titulo="plex-card mode=outlined align=start" size="sm"></plex-title>
+                <!-- outlined -->
+                <plex-grid type="auto" size="lg">
+
+                    <plex-card [color]="color" align="start" selectable="true" type="{{ dato.type }}"
                                *ngFor="let dato of datos | slice:0:6" [selected]="dato.selected"
                                (click)="dato.selected = !dato.selected">
                         <plex-badge type="warning">badge</plex-badge>
                         <plex-label size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
 
                         </plex-label>
-                        <plex-button type="warning" label="aceptar"></plex-button>
-                    </plex-card>
-                    <plex-card span="2" class="mt-1" aligned="center" type="dark" *ngFor="let dato of datos | slice:6:7"
-                               [selected]="dato.selected" (click)="dato.selected = !dato.selected">
-                        <plex-badge type="warning">badge</plex-badge>
-                        <plex-label direction="column" size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
-                                    icon="information-variant">
-                        </plex-label>
-                        <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
-                    </plex-card>
-                    <plex-card selectable="true" span="2" class="mt-1" align="center" styled="filled" type="dark"
-                               *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
-                               (click)="dato.selected = !dato.selected">
-                        <plex-badge type="warning">badge</plex-badge>
-                        <plex-label direction="column" size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}"
-                                    icon="information-variant">
-                        </plex-label>
-                        <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
-                    </plex-card>
-                </plex-grid>
-            </div>
-            <div span="2">
-                <plex-title titulo="plex-card aligned=center" size="sm"></plex-title>
-                <plex-grid type="auto" cols="2" size="md">
-                    <plex-card aligned="center" type="default" *ngFor="let agenda of agendas | slice:0:2"
-                               [selected]="agenda.selected" (click)="agenda.selected = !agenda.selected">
-                        <plex-badge type="{{ agenda.type }}">{{ agenda.type }}</plex-badge>
-                        <plex-badge type="info">{{ agenda.horario }}</plex-badge>
-                        <plex-label size="md" direction="column" type="{{ agenda.type }}"
-                                    titulo="{{ agenda.profesional }}" subtitulo="{{ agenda.prestacion }}" icon="star">
-                        </plex-label>
-                        <plex-button type="info" icon="eye" size="sm"></plex-button>
-                        <plex-button type="success" icon="plus" size="sm"></plex-button>
-                    </plex-card>
-                </plex-grid>
-                <hr>
-                <!-- Calendario -->
-                <plex-title titulo="plex-card: conjunto de celdas" size="sm"></plex-title>
-                <plex-grid type="auto" size="md">
-                    <plex-card aligned="center" type="default" *ngFor="let celda of calendario | slice:0:25"
-                               [selected]="celda.selected" (click)="celda.selected = !celda.selected">
-                        <plex-badge type="success">{{ celda.turnos }}</plex-badge>
-                        <plex-badge type="warning">{{ celda.agendas }}</plex-badge>
-                        <plex-label size="lg" titulo="{{ celda.fecha }}" subtitulo="">
-                        </plex-label>
-                        <plex-button type="warning" icon="pencil" size="sm"></plex-button>
+                        <plex-button type="warning" label="test"></plex-button>
                     </plex-card>
                 </plex-grid>
             </div>
         </plex-grid>
         <!-- Type Dark (invert) -->
+        <plex-title titulo="plex-card type='dark'" size="sm"></plex-title>
         <plex-grid cols="2">
-            <plex-card selectable="true" class="mt-1" align="center" type="dark" mode="filled"
+            <plex-card selectable="true" class="mt-1" aligned="center" type="dark" mode="filled"
                        *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
                        (click)="dato.selected = !dato.selected">
                 <plex-badge type="warning">badge</plex-badge>
@@ -89,7 +60,7 @@
                 </plex-label>
                 <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
             </plex-card>
-            <plex-card selectable="true" class="mt-1" align="center" mode="outlined" type="dark"
+            <plex-card selectable="true" class="mt-1" aligned="center" mode="outlined" type="dark"
                        *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
                        (click)="dato.selected = !dato.selected">
                 <plex-badge type="warning">badge</plex-badge>
@@ -103,7 +74,7 @@
             <!-- Calendario -->
             <plex-title titulo="plex-card: conjunto de celdas" size="sm"></plex-title>
             <plex-grid type="auto" size="md" noGap>
-                <plex-card align="center" type="default" *ngFor="let celda of calendario | slice:0:25"
+                <plex-card aligned="center" type="default" *ngFor="let celda of calendario | slice:0:25"
                            [selected]="celda.selected" (click)="celda.selected = !celda.selected">
                     <plex-badge type="success">{{ celda.turnos }}</plex-badge>
                     <plex-badge type="warning">{{ celda.agendas }}</plex-badge>
@@ -121,7 +92,7 @@
         <plex-title titulo="atributos y usos"></plex-title>
         <plex-title titulo="detalle de agendas" size="sm"></plex-title>
         <plex-grid type="full" size="md">
-            <plex-card aligned="start" type="" *ngFor="let agenda of agendas"
+            <plex-card align="start" type="" *ngFor="let agenda of agendas"
                        [ngClass]="{'disabled' : agenda.turnos === 'sin turnos'}">
                 <plex-badge type="{{ agenda.type }}">{{
                     agenda.turnos }}</plex-badge>
@@ -134,7 +105,7 @@
         </plex-grid>
         <plex-title titulo="plex-card con imagenes" size="sm"></plex-title>
         <plex-grid type="full" size="md" cols="2">
-            <plex-card aligned="start" type="" *ngFor="let efector of efectores">
+            <plex-card align="start" type="" *ngFor="let efector of efectores">
                 <img src="{{ efector.img }}" alt="">
                 <plex-label size="md" direction="row" titulo="{{ efector.nombre }}" subtitulo="{{ efector.localidad }}">
                 </plex-label>
@@ -146,8 +117,8 @@
         <hr>
         <plex-title titulo="grilla de horarios" size="sm"></plex-title>
         <plex-grid type="full" size="md">
-            <plex-card aligned="center" type="default" *ngFor="let turno of horarios" [selected]="turno.selected"
-                       (click)="turno.selected = !turno.selected">
+            <plex-card align="center" type="dark" mode="filled" *ngFor="let turno of horarios" selectable="true"
+                       [selected]="turno.selected" (click)="turno.selected = !turno.selected">
                 <plex-label size="md" direction="column" titulo="{{ turno.hora }}">
                 </plex-label>
             </plex-card>

--- a/src/demo/app/card/card.component.html
+++ b/src/demo/app/card/card.component.html
@@ -80,7 +80,7 @@
         </plex-grid>
         <!-- Type Dark (invert) -->
         <plex-grid cols="2">
-            <plex-card selectable="true" class="mt-1" align="center" type="dark" styled="filled"
+            <plex-card selectable="true" class="mt-1" align="center" type="dark" mode="filled"
                        *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
                        (click)="dato.selected = !dato.selected">
                 <plex-badge type="warning">badge</plex-badge>
@@ -89,7 +89,7 @@
                 </plex-label>
                 <plex-button type="{{ dato.type }}" label="aceptar"></plex-button>
             </plex-card>
-            <plex-card selectable="true" class="mt-1" align="center" styled="outlined" type="dark"
+            <plex-card selectable="true" class="mt-1" align="center" mode="outlined" type="dark"
                        *ngFor="let dato of datos | slice:6:7" [selected]="dato.selected"
                        (click)="dato.selected = !dato.selected">
                 <plex-badge type="warning">badge</plex-badge>

--- a/src/demo/app/card/card.component.ts
+++ b/src/demo/app/card/card.component.ts
@@ -8,13 +8,13 @@ export class CardDemoComponent {
     color = '#92278e';
 
     datos = [
-        { label: 'Funcionar como botones destacados en una interfaz', valor: 'Por ejemplo en puntos de inicio', type: 'default' },
-        { label: 'Representar opciones seleccionables', valor: 'Usuarios, organizaciones, items propios de un módulo', type: 'success' },
-        { label: 'Enriquecer las celdas de una grilla', valor: 'Por este motivo se combina con el componente plex-grid', type: 'info' },
-        { label: 'Card Warning', valor: 'Es un elemento seleccionable', type: 'warning' },
-        { label: 'Card Danger', valor: 'Es un elemento seleccionable', type: 'danger' },
-        { label: 'Card custom', valor: 'El color se define mediante el atributo [color]', type: 'custom' },
-        { label: 'Definir bloques de información destacada', valor: 'Recomendable la tipología "invert"', type: 'custom' },
+        { label: 'Funcionar como botones destacados en una interfaz', valor: 'Por ejemplo en puntos de inicio', type: 'default', style: 'filled' },
+        { label: 'Representar opciones seleccionables', valor: 'Usuarios, organizaciones, items propios de un módulo', type: 'success', style: 'filled' },
+        { label: 'Enriquecer las celdas de una grilla', valor: 'Por este motivo se combina con el componente plex-grid', type: 'info', style: 'filled' },
+        { label: 'Card Warning', valor: 'Es un elemento seleccionable', type: 'warning', style: 'filled' },
+        { label: 'Card Danger', valor: 'Es un elemento seleccionable', type: 'danger', style: 'filled' },
+        { label: 'Card custom', valor: 'El color se define mediante el atributo [color]', type: 'custom', style: 'filled' },
+        { label: 'Definir bloques de información destacada', valor: 'Recomendable la tipología "invert"', type: 'success', style: 'filled' },
     ];
 
     agendas = [

--- a/src/demo/app/directives/componentes/align/align.html
+++ b/src/demo/app/directives/componentes/align/align.html
@@ -14,21 +14,21 @@
 </h6>
 <plex-grid class="mt-4" cols="2" type="full" size="xl" vHeight="12">
     <div class="bg-info" align="center">
-        <plex-card type="dark" size="lg" aligned="center">
+        <plex-card type="dark" mode="filled" size="lg" aligned="center">
             <plex-label type="warning" titulo="align = center" subtitulo="La direcitva align tiene valor 'center'">
             </plex-label>
         </plex-card>
     </div>
     <section>
         <div class="bg-info" vheight="40" align="start">
-            <plex-card type="dark" size="lg" aligned="center">
+            <plex-card type="dark" mode="filled" size="lg" aligned="center">
                 <plex-label type="warning" titulo="align = start"
                             subtitulo="El atributo [vheight] con valor '40' (100% - 40vh)">
                 </plex-label>
             </plex-card>
         </div>
         <div class="bg-info mt-2 h-50" align="end">
-            <plex-card type="dark" size="lg" aligned="center">
+            <plex-card type="dark" mode="filled" size="lg" aligned="center">
                 <plex-label type="warning" titulo="align = end"
                             subtitulo="Este contenedor está al 50% del espacio disponible">
                 </plex-label>

--- a/src/demo/app/grid/grid.component.html
+++ b/src/demo/app/grid/grid.component.html
@@ -12,8 +12,8 @@
                 <section>
                     <plex-title titulo="size='xs'" size="sm"></plex-title>
                     <plex-grid type="auto" size="xs">
-                        <plex-card direction="column" type="custom" color="{{ dato.color }}" aligned="center"
-                                   *ngFor="let dato of datos | slice:0:1">
+                        <plex-card direction="column" type="custom" mode="filled" color="{{ dato.color }}"
+                                   aligned="center" *ngFor="let dato of datos | slice:0:1">
                             <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                             </plex-label>
                         </plex-card>
@@ -22,8 +22,8 @@
                 <section>
                     <plex-title titulo="size='sm'" size="sm"></plex-title>
                     <plex-grid type="auto" size="sm">
-                        <plex-card direction="column" type="custom" color="{{ dato.color }}" aligned="center"
-                                   *ngFor="let dato of datos | slice:1:2">
+                        <plex-card direction="column" type="custom" mode="filled" color="{{ dato.color }}"
+                                   aligned="center" *ngFor="let dato of datos | slice:1:2">
                             <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                             </plex-label>
                         </plex-card>
@@ -32,8 +32,8 @@
                 <section>
                     <plex-title titulo="size='md'" size="sm"></plex-title>
                     <plex-grid type="auto" size="md">
-                        <plex-card direction="column" type="custom" color="{{ dato.color }}" aligned="center"
-                                   *ngFor="let dato of datos | slice:2:3">
+                        <plex-card direction="column" type="custom" mode="filled" color="{{ dato.color }}"
+                                   aligned="center" *ngFor="let dato of datos | slice:2:3">
                             <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                             </plex-label>
                         </plex-card>
@@ -44,8 +44,8 @@
                 <section>
                     <plex-title titulo="size='lg'" size="sm"></plex-title>
                     <plex-grid type="auto" size="lg">
-                        <plex-card direction="column" type="custom" color="{{ dato.color }}" aligned="center"
-                                   *ngFor="let dato of datos | slice:3:4">
+                        <plex-card direction="column" type="custom" mode="filled" color="{{ dato.color }}"
+                                   aligned="center" *ngFor="let dato of datos | slice:3:4">
                             <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                             </plex-label>
                         </plex-card>
@@ -54,8 +54,8 @@
                 <section>
                     <plex-title titulo="size='xl'" size="sm"></plex-title>
                     <plex-grid type="auto" size="xl">
-                        <plex-card direction="column" type="custom" color="{{ dato.color }}" aligned="center"
-                                   *ngFor="let dato of datos | slice:4:5">
+                        <plex-card direction="column" type="custom" mode="filled" color="{{ dato.color }}"
+                                   aligned="center" *ngFor="let dato of datos | slice:4:5">
                             <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                             </plex-label>
                         </plex-card>
@@ -69,7 +69,8 @@
                 <plex-title titulo="Encolumnado manual: colsSm | colsMd | colsLg (expandir sidebar!)" size="sm">
                 </plex-title>
                 <plex-grid responsive type="full" size="md" cols="3" colsSm="1" colsMd="2" colsLg="3">
-                    <plex-card direction="column" type="info" aligned="center" *ngFor="let dato of datos | slice:0:3">
+                    <plex-card direction="column" type="info" mode="filled" aligned="center"
+                               *ngFor="let dato of datos | slice:0:3">
                         <plex-label size="lg" titulo="{{ dato.label }}" subtitulo="{{ dato.valor }}">
                         </plex-label>
                     </plex-card>
@@ -80,13 +81,15 @@
                 <plex-title titulo="atributo 'cols' (columnas fijas) | cols= '2' | ... | '12'" size="sm">
                 </plex-title>
                 <plex-grid type="auto" size="md" cols="2">
-                    <plex-card direction="column" type="info" aligned="center" *ngFor="let dato of datos | slice:0:2">
+                    <plex-card direction="column" type="info" mode="filled" aligned="center"
+                               *ngFor="let dato of datos | slice:0:2">
                         <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                         </plex-label>
                     </plex-card>
                 </plex-grid>
                 <plex-grid type="auto" size="md" cols="3">
-                    <plex-card direction="column" type="info" aligned="center" *ngFor="let dato of datos | slice:2:5">
+                    <plex-card direction="column" type="info" mode="filled" aligned="center"
+                               *ngFor="let dato of datos | slice:2:5">
                         <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                         </plex-label>
                     </plex-card>
@@ -101,7 +104,8 @@
         <plex-title titulo="plex-grid type='full'" size="sm"></plex-title>
         <h6>La propiedad 'full' genera que las celdas que integran la grilla ocupen todo el espacio disponible.</h6>
         <plex-grid type="full" size="sm">
-            <plex-card direction="column" type="warning" aligned="center" *ngFor="let dato of datos | slice:0:3">
+            <plex-card direction="column" type="warning" mode="filled" aligned="center"
+                       *ngFor="let dato of datos | slice:0:3">
                 <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                 </plex-label>
             </plex-card>
@@ -109,7 +113,8 @@
         <plex-title titulo="plex-grid type='auto'" size="sm"></plex-title>
         <h6>La propiedad 'auto' implica que las celdas que componen la grilla mantengan su aspecto original.</h6>
         <plex-grid type="auto" size="sm">
-            <plex-card direction="column" type="warning" aligned="center" *ngFor="let dato of datos | slice:0:3">
+            <plex-card direction="column" type="warning" mode="filled" aligned="center"
+                       *ngFor="let dato of datos | slice:0:3">
                 <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                 </plex-label>
             </plex-card>
@@ -126,11 +131,12 @@
         <h6>Es aplicable a los elementos que integran el plex-grid. El valor asignado determina la cantidad de columnas
             que ocupa el elemento.</h6>
         <plex-grid cols="3" size="md" *ngFor="let dato of datos | slice:0:1">
-            <plex-card span="2" direction="column" type="custom" color="{{ dato.color }}" aligned="center">
+            <plex-card span="2" direction="column" type="custom" mode="filled" color="{{ dato.color }}"
+                       aligned="center">
                 <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                 </plex-label>
             </plex-card>
-            <plex-card direction="column" type="info" aligned="center">
+            <plex-card direction="column" type="info" mode="filled" aligned="center">
                 <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                 </plex-label>
             </plex-card>
@@ -138,7 +144,7 @@
         <!-- sin calles -->
         <plex-title titulo="plex-grid [noGap] (grilla sin espacios)" size="sm"></plex-title>
         <plex-grid gap="true" type="auto" size="md">
-            <plex-card direction="column" type="custom" color="{{ dato.color }}" aligned="center"
+            <plex-card direction="column" type="custom" mode="filled" color="{{ dato.color }}" aligned="center"
                        *ngFor="let dato of datos | slice:0:3">
                 <plex-label size="xl" titulo="{{ dato.label }}" subtitulo="">
                 </plex-label>

--- a/src/lib/card/card.component.ts
+++ b/src/lib/card/card.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, ViewChild, ElementRef, OnChanges } from '@angular/cor
 @Component({
     selector: 'plex-card',
     template: `
-    <div #cardColor class="card bg-{{ styled }}-{{ type }}" [ngClass]="{ 'text-white' : type === 'dark', 'selectable' : selectable }" [class.selected]="selected">
+    <div #cardColor class="card bg-{{ styled }}-{{ type }}" [ngClass]="{ 'selectable' : selectable }" [class.selected]="selected">
         <ng-content select="img"></ng-content>
         <ng-content select="plex-icon"></ng-content>
         <div class="d-flex" [ngClass]="cssAlign">
@@ -48,6 +48,10 @@ export class PlexCardComponent implements OnChanges {
     ngOnChanges() {
         if (this.color && this.color.length > 0) {
             this.cardColor.nativeElement.style.setProperty('--card-color', this.color);
+        }
+
+        if (this.color && this.color.length > 0 && this.styled === 'outlined') {
+            this.cardColor.nativeElement.style.setProperty('--card-color', this.color + '20');
         }
     }
 }

--- a/src/lib/card/card.component.ts
+++ b/src/lib/card/card.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, ViewChild, ElementRef, OnChanges } from '@angular/cor
 @Component({
     selector: 'plex-card',
     template: `
-    <div #cardColor class="card bg-{{ styled }}-{{ type }}" [ngClass]="{ 'selectable' : selectable }" [class.selected]="selected">
+    <div #cardColor class="card bg-{{ mode }}-{{ type }}" [ngClass]="{ 'selectable' : selectable }" [class.selected]="selected">
         <ng-content select="img"></ng-content>
         <ng-content select="plex-icon"></ng-content>
         <div class="d-flex" [ngClass]="cssAlign">
@@ -29,7 +29,7 @@ export class PlexCardComponent implements OnChanges {
     @Input() align: 'start' | 'end' | 'center' = 'center';
     @Input() size: 'xs' | 'md' | 'lg' | 'block' = 'md';
     @Input() type: 'info' | 'success' | 'warning' | 'danger' | 'dark' | 'custom' | 'default' = 'default';
-    @Input() styled: 'filled' | 'outlined' = 'outlined';
+    @Input() mode: 'filled' | 'outlined' = 'outlined';
     @Input() color: string;
 
     @ViewChild('cardColor', { static: true }) cardColor: ElementRef;
@@ -50,7 +50,7 @@ export class PlexCardComponent implements OnChanges {
             this.cardColor.nativeElement.style.setProperty('--card-color', this.color);
         }
 
-        if (this.color && this.color.length > 0 && this.styled === 'outlined') {
+        if (this.color && this.color.length > 0 && this.mode === 'outlined') {
             this.cardColor.nativeElement.style.setProperty('--card-color', this.color + '20');
         }
     }

--- a/src/lib/card/card.component.ts
+++ b/src/lib/card/card.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, ViewChild, ElementRef, OnChanges } from '@angular/cor
 @Component({
     selector: 'plex-card',
     template: `
-    <div #cardColor class="card bg-{{ type }}" [ngClass]="{'text-white' : type != 'default'}" [class.selected]="selected">
+    <div #cardColor class="card bg-{{ styled }}-{{ type }}" [ngClass]="{ 'text-white' : type === 'dark', 'selectable' : selectable }" [class.selected]="selected">
         <ng-content select="img"></ng-content>
         <ng-content select="plex-icon"></ng-content>
         <div class="d-flex" [ngClass]="cssAlign">
@@ -25,8 +25,11 @@ import { Component, Input, ViewChild, ElementRef, OnChanges } from '@angular/cor
 export class PlexCardComponent implements OnChanges {
     @Input() selected = false;
     @Input() aligned: 'start' | 'end' | 'center' = 'center';
+    @Input() selectable = false;
+    @Input() align: 'start' | 'end' | 'center' = 'center';
     @Input() size: 'xs' | 'md' | 'lg' | 'block' = 'md';
-    @Input() type: 'success' | 'warning' | 'danger' | 'dark' | 'custom' | 'default' = 'default';
+    @Input() type: 'info' | 'success' | 'warning' | 'danger' | 'dark' | 'custom' | 'default' = 'default';
+    @Input() styled: 'filled' | 'outlined' = 'outlined';
     @Input() color: string;
 
     @ViewChild('cardColor', { static: true }) cardColor: ElementRef;

--- a/src/lib/css/classes.scss
+++ b/src/lib/css/classes.scss
@@ -36,6 +36,8 @@
   }
 }
 
+/* IMPORTANTE */
+/*  Al utilizar esta clase, asegurarse que sea acompañada por el atributo [disabled] o alguna condición que no permita interacción alguna */
 .disabled {
     pointer-events: none!important;
     user-select: none!important;

--- a/src/lib/css/mixins/_contrast.scss
+++ b/src/lib/css/mixins/_contrast.scss
@@ -1,0 +1,12 @@
+@mixin text-contrast($n) {
+  $color-brightness: round((red($n) * 299) + (green($n) * 587) + (blue($n) * 114) / 1000);
+  $light-color: round((red(#ffffff) * 299) + (green(#ffffff) * 587) + (blue(#ffffff) * 114) / 1000);
+  
+  @if abs($color-brightness) < ($light-color/2){
+    color: white;
+  }
+
+  @else {
+    color: black;
+  }
+}

--- a/src/lib/css/plex-card.scss
+++ b/src/lib/css/plex-card.scss
@@ -2,8 +2,10 @@
 @import './mixins/cardBackground.scss';
 
 plex-card {
-    cursor: pointer;
     box-sizing: border-box;
+    &[selectable] {
+        cursor: pointer;
+    }
 
     .card {
         display: flex;
@@ -13,6 +15,7 @@ plex-card {
         
         > img, > plex-icon {
             margin-bottom: .75rem;
+            object-fit: cover!important;
         }
 
         div {
@@ -25,19 +28,6 @@ plex-card {
         }
     }
     
-    // Estados
-    > .card:hover {
-        color: var(--color-tipo)!important;
-        background-color: var(--color-baseDark)!important;
-        box-shadow: inset 0 0 0 3px var(--color-baseDarker)!important;
-    }   
-    
-    > .card.selected {
-        background-color: var(--color-baseDark)!important;
-        color: var(--color-tipo)!important;
-        box-shadow: inset 0 0 0 3px var(--color-baseDarker)!important;
-    }
-    
     //Custom color
     >div.card {
         &.bg-custom {
@@ -47,42 +37,115 @@ plex-card {
             --color-base: var(--card-color);
             --color-baseLight: white;
             --color-baseDark: var(--card-color);
-            
+        &.selectable {
             &:hover, &.selected {
                 box-shadow: inset 0 0 0 3px $blue!important;                            
                 filter: brightness(0.85);
+                }            
             }
+        }
+    }
+
+    // SUCCESS
+    @mixin filledCardHover {   
+        &.selectable {
+            &:hover, &.selected {
+                box-shadow: inset 0 0 0 3px var(--color-baseDarker)!important;
+                background-color: var(--color-baseDark)!important;
+                color: var(--color-tipo)!important;              
             }
+        }
+    }
+
+    @mixin outlinedCardHover {   
+        &.selectable {
+            &:hover, &.selected {
+                box-shadow: inset 0 0 0 3px var(--color-baseDark)!important;
+                background-color: var(--color-baseLight)!important;
+                color: var(---color-tipo)!important;              
+            }
+        }
+    }
+
+    > div {
+        // DEFAULT
+        // filled
+        &.bg-filled-default {
+            --color-baseLight: #d9f4ff;
+            --color-base: white;
+            --color-tipo: #002738;
+            --color-baseDark: #00a8e0;
+            --color-baseDarker: #00a8e0;
+            
+            @include cardBackground;
+            background-color: var(--color-base)!important;
+            @include filledCardHover;
+        }
+        
+        // outlined
+        &.bg-outlined-default {
+            --color-baseLight: #d9f4ff;
+            --color-base: white;
+            --color-tipo: #002738;
+            --color-baseDark: #00a8e0;
+            --color-baseDarker: #00a8e0;
+            
+            box-shadow: inset 0 0 0 2px var(--color-base);
+            @include outlinedCardHover;
         }
     
-        // Default
-        > div.bg-default {
-        --color-base: white;
-        --color-tipo: #002738;
-        --color-baseDark: #edf8fd;
-        --color-baseDarker: #00a8e0;
-        }
-
-        // Dark
-        > div.bg-dark {
+        // DARK
+        // filled
+        &.bg-filled-dark {
             --color-base: #002738;
             --color-tipo: white;
             --color-baseDark: #00202e;
             --color-baseDarker: #00a8e0;
+                        
+            @include cardBackground;
+            background-color: var(--color-base)!important;
+            @include filledCardHover;
+        }
+        
+        // outlined
+        &.bg-outlined-dark {
+            --color-base: #002738;
+            --color-tipo: white;
+            --color-baseDark: #00202e;
+            --color-baseDarker: #00a8e0;
+            
+            box-shadow: inset 0 0 0 2px var(--color-base);
+            @include outlinedCardHover;
         }
 
-        // Success
-        > div.bg-success {
-            @include cardBackground;
+        // SUCCESS
+        // filled
+        &.bg-filled-success {
             --color-baseLight: #c7e79c;
             --color-base: #8cc63f;
             --color-tipo: white;
             --color-baseDark: #70a728;
             --color-baseDarker: #55801e;
+
+            @include cardBackground;
+            background-color: var(--color-base)!important;
+            @include filledCardHover;
+        }
+
+        // outlined
+        &.bg-outlined-success {
+            --color-baseLight: #e9fad1;
+            --color-base: #8cc63f;
+            --color-tipo: white;
+            --color-baseDark: #70a728;
+            --color-baseDarker: #55801e;
+
+            box-shadow: inset 0 0 0 2px var(--color-base);
+            @include outlinedCardHover;
         }
 
         // Warning
-        > div.bg-warning {
+        &.bg-filled-warning {
             @include cardBackground;
             --color-baseLight: #fdc189;
             --color-base: #ff8d22;
@@ -90,9 +153,21 @@ plex-card {
             --color-baseDark: #e47814;
             --color-baseDarker: #c55f00;
         }
+        
+        // outlined
+        &.bg-outlined-warning {
+            --color-baseLight: #fdc189;
+            --color-base: #ff8d22;
+            --color-tipo: white;
+            --color-baseDark: #e47814;
+            --color-baseDarker: #c55f00;
 
+            box-shadow: inset 0 0 0 2px var(--color-base);
+            @include outlinedCardHover;
+        }
+            
         // Danger
-        > div.bg-danger {
+        &.bg-filled-danger {
             @include cardBackground;
             --color-baseLight: #ffb3a9;
             --color-base: #dd4b39;
@@ -100,9 +175,21 @@ plex-card {
             --color-baseDark: #b9311f;
             --color-baseDarker: #a12514;
         }
+        
+        // outlined
+        &.bg-outlined-danger {
+            --color-baseLight: #ffb3a9;
+            --color-base: #dd4b39;
+            --color-tipo: white;
+            --color-baseDark: #b9311f;
+            --color-baseDarker: #a12514;
 
+            box-shadow: inset 0 0 0 2px var(--color-base);
+            @include outlinedCardHover;
+        }
+    
         // Info
-        > div.bg-info {
+        &.bg-filled-info {
             @include cardBackground;
             --color-baseLight: #c2e6f6;
             --color-base: #00a8e0;
@@ -110,6 +197,19 @@ plex-card {
             --color-baseDark: #0695c5;
             --color-baseDarker: #057ea7;
         }
+        
+        // outlined
+        &.bg-outlined-info {
+            --color-baseLight: #c2e6f6;
+            --color-base: #00a8e0;
+            --color-tipo: white;
+            --color-baseDark: #0695c5;
+            --color-baseDarker: #057ea7;
+
+            box-shadow: inset 0 0 0 2px var(--color-base);
+            @include outlinedCardHover;
+        }
+    }
 
     // Version invert
     &[type="dark"] {

--- a/src/lib/css/plex-card.scss
+++ b/src/lib/css/plex-card.scss
@@ -1,5 +1,6 @@
 @import './variables.scss';
 @import './mixins/cardBackground.scss';
+@import './mixins/_contrast.scss';
 
 plex-card {
     box-sizing: border-box;
@@ -28,193 +29,219 @@ plex-card {
         }
     }
     
-    //Custom color
-    >div.card {
-        &.bg-custom {
-            @include cardBackground;
-            background-color: var(--card-color);
-            --color-tipo: white;
-            --color-base: var(--card-color);
-            --color-baseLight: white;
-            --color-baseDark: var(--card-color);
+    // Estados interactivos
+    @mixin filledCardHover {
         &.selectable {
             &:hover, &.selected {
-                box-shadow: inset 0 0 0 3px $blue!important;                            
-                filter: brightness(0.85);
-                }            
-            }
-        }
-    }
-
-    // SUCCESS
-    @mixin filledCardHover {   
-        &.selectable {
-            &:hover, &.selected {
-                box-shadow: inset 0 0 0 3px var(--color-baseDarker)!important;
+                box-shadow: inset 0 0 0 2px var(--color-baseDarker)!important;
                 background-color: var(--color-baseDark)!important;
-                color: var(--color-tipo)!important;              
             }
         }
     }
 
-    @mixin outlinedCardHover {   
+    @mixin outlinedCardHover {
         &.selectable {
             &:hover, &.selected {
-                box-shadow: inset 0 0 0 3px var(--color-baseDark)!important;
+                box-shadow: inset 0 0 0 2px var(--color-base)!important;
                 background-color: var(--color-baseLight)!important;
-                color: var(---color-tipo)!important;              
+            }
+        }
+    }
+
+    @mixin customCardHover {
+        &.selectable {
+            &:hover, &.selected {
+                box-shadow: inset 0 0 0 2px var(--color-base)!important;
+                background-color: var(--color-base)!important;
+                filter: brightness(0.9);
             }
         }
     }
 
     > div {
+        --lighten: 50%;
+        --darken: 10%;
+        --darkest: 25%;
+        --color-baseLight: hsl(var(--colorDominante-h), var(--colorDominante-s), calc(var(--colorDominante-l) + var(--lighten)));
+        --color-base: hsl(var(--colorDominante-h), var(--colorDominante-s), var(--colorDominante-l));
+        --color-baseDark: hsl(var(--colorDominante-h), var(--colorDominante-s), calc(var(--colorDominante-l) - var(--darken )));
+        --color-baseDarker: hsl(var(--colorDominante-h), var(--colorDominante-s), calc(var(--colorDominante-l) - var(--darkest )));
+
         // DEFAULT
         // filled
-        &.bg-filled-default {
-            --color-baseLight: #d9f4ff;
-            --color-base: white;
-            --color-tipo: #002738;
-            --color-baseDark: #00a8e0;
-            --color-baseDarker: #00a8e0;
-            
-            @include cardBackground;
+        &.bg-filled-default {   
+            // descomposición del dominante
+            --colorDominante-h: 0;
+            --colorDominante-s: 0%;
+            --colorDominante-l: 90%;
+
             background-color: var(--color-base)!important;
             @include filledCardHover;
+            @include text-contrast(white);
         }
         
         // outlined
         &.bg-outlined-default {
-            --color-baseLight: #d9f4ff;
-            --color-base: white;
-            --color-tipo: #002738;
-            --color-baseDark: #00a8e0;
-            --color-baseDarker: #00a8e0;
-            
-            box-shadow: inset 0 0 0 2px var(--color-base);
+            --lighten: 25%;
+            --colorDominante-h: 0;
+            --colorDominante-s: 0%;
+            --colorDominante-l: 70%;
+
+            //box-shadow: inset 0 0 0 2px var(--color-base);
             @include outlinedCardHover;
+            // calculo contraste en funcion del dominante
+            @include text-contrast(white);
         }
     
         // DARK
         // filled
         &.bg-filled-dark {
-            --color-base: #002738;
-            --color-tipo: white;
-            --color-baseDark: #00202e;
-            --color-baseDarker: #00a8e0;
-                        
-            @include cardBackground;
+            --lighten: 10%;
+            --colorDominante-h: 198;
+            --colorDominante-s: 100%;
+            --colorDominante-l: 11%;
+                
             background-color: var(--color-base)!important;
-            @include filledCardHover;
+            @include outlinedCardHover;
+            @include text-contrast(black);
         }
         
         // outlined
         &.bg-outlined-dark {
-            --color-base: #002738;
-            --color-tipo: white;
-            --color-baseDark: #00202e;
-            --color-baseDarker: #00a8e0;
+            --lighten: 85%;
+            --colorDominante-h: 198;
+            --colorDominante-s: 100%;
+            --colorDominante-l: 11%;
             
             box-shadow: inset 0 0 0 2px var(--color-base);
             @include outlinedCardHover;
+            @include text-contrast(white);
         }
+
+        // CUSTOM
+        &.bg-filled-custom {
+            --color-base: var(--card-color);
+            --color-baseDark: var(--card-color);
+
+            @include cardBackground;
+            background-color: var(--card-color)!important;
+            @include customCardHover;
+            @include text-contrast(black);
+        }
+
+        &.bg-outlined-custom {
+            --color-base: var(--card-color);
+            --color-baseDark: var(--card-color);
+            box-shadow: inset 0 0 0 2px var(--card-color);
+
+            @include customCardHover;
+            // calculo contraste en funcion del dominante
+            @include text-contrast(white);
+        }
+
 
         // SUCCESS
         // filled
         &.bg-filled-success {
-            --color-baseLight: #c7e79c;
-            --color-base: #8cc63f;
-            --color-tipo: white;
-            --color-baseDark: #70a728;
-            --color-baseDarker: #55801e;
-
+            --lighten: 40%;
+            // descomposición del dominante
+            --colorDominante-h: 86;
+            --colorDominante-s: 56%;
+            --colorDominante-l: 51%;
             @include cardBackground;
             background-color: var(--color-base)!important;
             @include filledCardHover;
+            @include text-contrast(#70a728);
         }
 
         // outlined
         &.bg-outlined-success {
-            --color-baseLight: #e9fad1;
-            --color-base: #8cc63f;
-            --color-tipo: white;
-            --color-baseDark: #70a728;
-            --color-baseDarker: #55801e;
-
+            --lighten: 40%;
+            // descomposición del dominante
+            --colorDominante-h: 86;
+            --colorDominante-s: 56%;
+            --colorDominante-l: 51%;
             box-shadow: inset 0 0 0 2px var(--color-base);
             @include outlinedCardHover;
+            // calculo contraste en funcion del dominante
+            @include text-contrast(#8cc63f);
         }
 
-        // Warning
+        // WARNING
         &.bg-filled-warning {
+            --lighten: 35%;
+            // descomposición del dominante
+            --colorDominante-h: 29;
+            --colorDominante-s: 100%;
+            --colorDominante-l: 57%;
+
             @include cardBackground;
-            --color-baseLight: #fdc189;
-            --color-base: #ff8d22;
-            --color-tipo: white;
-            --color-baseDark: #e47814;
-            --color-baseDarker: #c55f00;
+            background-color: var(--color-base)!important;
+            @include filledCardHover;
+            @include text-contrast(#c55f00);
         }
         
         // outlined
         &.bg-outlined-warning {
-            --color-baseLight: #fdc189;
-            --color-base: #ff8d22;
-            --color-tipo: white;
-            --color-baseDark: #e47814;
-            --color-baseDarker: #c55f00;
-
+            --lighten: 35%;
+            // descomposición del dominante
+            --colorDominante-h: 29;
+            --colorDominante-s: 100%;
+            --colorDominante-l: 57%;
             box-shadow: inset 0 0 0 2px var(--color-base);
             @include outlinedCardHover;
+            // calculo contraste en funcion del dominante
+            @include text-contrast(#fdc189);
         }
             
-        // Danger
+        // Dominante
         &.bg-filled-danger {
+            --lighten: 35%;
+            // descomposición del dominante
+            --colorDominante-h: 7;
+            --colorDominante-s: 71%;
+            --colorDominante-l: 55%;
             @include cardBackground;
-            --color-baseLight: #ffb3a9;
-            --color-base: #dd4b39;
-            --color-tipo: white;
-            --color-baseDark: #b9311f;
-            --color-baseDarker: #a12514;
+            background-color: var(--color-base)!important;
+            @include filledCardHover;
+            @include text-contrast(#b9311f);
         }
         
         // outlined
         &.bg-outlined-danger {
-            --color-baseLight: #ffb3a9;
-            --color-base: #dd4b39;
-            --color-tipo: white;
-            --color-baseDark: #b9311f;
-            --color-baseDarker: #a12514;
-
+            --lighten: 35%;
+            // descomposición del dominante
+            --colorDominante-h: 7;
+            --colorDominante-s: 71%;
+            --colorDominante-l: 55%;
             box-shadow: inset 0 0 0 2px var(--color-base);
             @include outlinedCardHover;
+            // calculo contraste en funcion del dominante
+            @include text-contrast(#fdc189);
         }
     
         // Info
         &.bg-filled-info {
+            // descomposición del dominante
+            --colorDominante-h: 195;
+            --colorDominante-s: 100%;
+            --colorDominante-l: 44%;
             @include cardBackground;
-            --color-baseLight: #c2e6f6;
-            --color-base: #00a8e0;
-            --color-tipo: white;
-            --color-baseDark: #0695c5;
-            --color-baseDarker: #057ea7;
+            background-color: var(--color-base)!important;
+            @include filledCardHover;
+            @include text-contrast(#057ea7);
         }
         
         // outlined
         &.bg-outlined-info {
-            --color-baseLight: #c2e6f6;
-            --color-base: #00a8e0;
-            --color-tipo: white;
-            --color-baseDark: #0695c5;
-            --color-baseDarker: #057ea7;
-
+            // descomposición del dominante
+            --colorDominante-h: 195;
+            --colorDominante-s: 100%;
+            --colorDominante-l: 44%;
             box-shadow: inset 0 0 0 2px var(--color-base);
             @include outlinedCardHover;
-        }
-    }
-
-    // Version invert
-    &[type="dark"] {
-        > div {
-            background-color: $dark-blue;
+            // calculo contraste en funcion del dominante
+            @include text-contrast(#c2e6f6);
         }
     }
 


### PR DESCRIPTION
- Se refactoriza la hoja de estilos incorporando mixins y custom-properties que permiten simplificar los cálculos en las variantes cromáticas (brillo y saturación)
- Se resuelve tipología custom outlined desde el .ts (como opción al método darken/lighten)
- Se incluye un mixin para calcular colores accesibles (optimiza contrastes)
- Se actualiza la demo del componente