### PR TITLE
feat(plex-button): agrega atributo aria-label

### DIFF
--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -5,7 +5,7 @@
 
         <plex-title size="sm" titulo="Tipos"></plex-title>
         <plex-button label="Default" (click)="onClick()" [autodisabled]="true"></plex-button>
-        <plex-button label="Info" type="info"></plex-button>
+        <plex-button label="Info" ariaLabel="soy un boton type info" type="info"></plex-button>
         <plex-button label="Danger" type="danger"></plex-button>
         <plex-button label="Warning" type="warning"></plex-button>
         <plex-button label="Success" type="success"></plex-button>
@@ -25,8 +25,8 @@
         <hr>
         <plex-title size="sm" titulo="Grupos"></plex-title>
         <div class="btn-group">
-            <plex-button type="success" icon="account"></plex-button>
-            <plex-button type="danger" icon="clock"></plex-button>
+            <plex-button type="success" icon="account" ariaLabel="boton que valida una operación"></plex-button>
+            <plex-button type="danger" icon="clock" ariaLabel="boton que ejecuta una acción sensible"></plex-button>
         </div>
         <hr>
         <plex-title size="sm" titulo="Validación de formularios"></plex-title>

--- a/src/lib/button/button.component.ts
+++ b/src/lib/button/button.component.ts
@@ -8,7 +8,7 @@ import { takeUntil } from 'rxjs/operators';
     selector: 'plex-button',
     template: `
         <ng-container *ngIf="type">
-                <button plexRipples style="pointer-events: auto" [tabIndex]="tabIndex" class="btn btn-{{type}} {{(size ? 'btn-' + size : '')}}" [disabled]="disabled">
+                <button plexRipples style="pointer-events: auto" [tabIndex]="tabIndex" [attr.aria-label]="ariaLabel" class="btn btn-{{type}} {{(size ? 'btn-' + size : '')}}" [disabled]="disabled">
                     <plex-icon
                         *ngIf="icon"
                         [name]="icon"
@@ -26,6 +26,7 @@ import { takeUntil } from 'rxjs/operators';
 })
 export class PlexButtonComponent implements OnInit, OnDestroy {
     @Input() tabIndex: number;
+    @Input() ariaLabel: string;
     @Input() label: string;
     @Input() icon: string;
     @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'default';


### PR DESCRIPTION
[PLEX-248](https://proyectos.andes.gob.ar/browse/PLEX-248)

**Contexto**
Actualmente, diversos componente PLEX carecen de éste atributo, imposibilitando ser percibidos por lectores de pantalla.

**Problema**
Dificultad para brindar información en botones con ausencia de texto (acciones iconográficas).

**Solución**
Se agrega @Input() ariaLabel a nivel componente y se pasa el string a un atributo aria-label a nivel HTML. 
