### PR TITLE
fix(plex-modal): se evita herencia desde invert

### DIFF
--- a/src/demo/app/templates/componentes/plex-modal-template/plex-modal-template.html
+++ b/src/demo/app/templates/componentes/plex-modal-template/plex-modal-template.html
@@ -180,10 +180,12 @@
                 <plex-list size="sm" class="w-100">
                     <plex-item>
                         <plex-label>PACIENTE 1</plex-label>
+                        <plex-badge type="success" size="sm" icon="star">Femenino</plex-badge>
                     </plex-item>
                     <hr>
                     <plex-item>
                         <plex-label>PACIENTE 2</plex-label>
+                        <plex-badge type="success" size="sm" icon="star">Masculino</plex-badge>
                     </plex-item>
                 </plex-list>
             </main>

--- a/src/demo/app/templates/componentes/plex-modal-template/plex-modal-template.html
+++ b/src/demo/app/templates/componentes/plex-modal-template/plex-modal-template.html
@@ -1,22 +1,22 @@
-<plex-layout>
+<plex-layout main="9">
     <plex-layout-main>
         <plex-title titulo="Ventanas Modales">
             <plex-badge type="danger">
-                Modal md (50% ancho) con Formulario
+                md (50% ancho) con Formulario
                 <plex-button icon="eye" (click)="openModal(0)">
                 </plex-button>
             </plex-badge>
             <plex-badge type="warning" class="ml-2">
-                Modal md con texto largo
+                md con texto largo
                 <plex-button icon="eye" (click)="openModal(1)">
                 </plex-button>
             </plex-badge>
             <plex-badge type="success" class="ml-2">
-                Modal sm (25% ancho)
+                sm (25% ancho)
                 <plex-button icon="eye" (click)="openModal(2)"></plex-button>
             </plex-badge>
             <plex-badge type="info" class="ml-2">
-                Modal lg (80% ancho)
+                lg (80% ancho)
                 <plex-button icon="eye" (click)="openModal(3)"></plex-button>
             </plex-badge>
         </plex-title>
@@ -136,11 +136,11 @@
                 <div>
                     <plex-title size="sm" titulo="Con mayor funcionalidad"></plex-title>
                     Ya que además de permitir estilos
-                    <u class="text-warning hover" title="tengo complejos">más complejos</u>, puede<br>
+                    <u class="text-warning hover" tooltip="tengo complejos">más complejos</u>, puede
                     contener formularios y otros componentes
                     <div class="mt-2">
                         <b>
-                            Este modal se puede cerrar con la tecla ESC, con la cruz en la esquina superior derecha, o
+                            Este modal se puede cerrar con el botón "Aceptar", con la tecla ESC, con la cruz en la esquina superior derecha, o
                             haciendo click fuera del mismo.
                         </b>
                     </div>
@@ -167,4 +167,32 @@
         </plex-modal>
 
     </plex-layout-main>
+    <plex-layout-sidebar type="invert">
+        <plex-title size="md" titulo="Modal en sidebar">
+            <plex-button icon="eye" type="info" size="sm" (click)="openModal(4)"></plex-button>
+        </plex-title>
+        <plex-modal size="sm" #modal [startOpen]="false" (closed)="notificarAccion(false)">
+            <plex-modal-title type="info">Modal dentro de un plex-sidebar invert</plex-modal-title>
+            <main>
+                <p>
+                    Un componente que abarca toda la pantalla o el foco de la misma, como un modal o un alert, nunca deben heredar estilos del contendor.
+                </p>
+                <plex-list size="sm" class="w-100">
+                    <plex-item>
+                        <plex-label>PACIENTE 1</plex-label>
+                    </plex-item>
+                    <hr>
+                    <plex-item>
+                        <plex-label>PACIENTE 2</plex-label>
+                    </plex-item>
+                </plex-list>
+            </main>
+            <plex-button modal left type="danger" (click)="closeModal(4)">
+                CANCELAR
+            </plex-button>
+            <plex-button modal right type="success" (click)="closeModal(4)">
+                ACEPTAR
+            </plex-button>
+        </plex-modal>
+    </plex-layout-sidebar>
 </plex-layout>

--- a/src/lib/css/plex-box.scss
+++ b/src/lib/css/plex-box.scss
@@ -73,14 +73,19 @@ plex-box > DIV {
         background: rgba(255, 255, 255, 0.1);
     }
 
+    plex-modal {
+        :not(plex-button *) {
+            color: #292b2c;
+        }
+    }
+
     plex-list {
         section.item {
-            background-color: transparentize($color: $blue, $amount: 0.9) !important;
+            background-color: transparentize($color: $blue, $amount: 0.9);
 
             &.selectable {
                 &:hover {
-                    box-shadow: inset 0 0 0 2px transparentize($color: $blue, $amount: 0.6) !important;
-                    background-color: rgba($blue, 0.2) !important;
+                    box-shadow: inset 0 0 0 2px transparentize($color: $blue, $amount: 0.6);
                     color: $light-blue;
                 }
             }

--- a/src/lib/css/plex-box.scss
+++ b/src/lib/css/plex-box.scss
@@ -74,8 +74,11 @@ plex-box > DIV {
     }
 
     plex-modal {
-        :not(plex-button *) {
-            color: #292b2c;
+        color: initial !important;
+        plex-list {
+            section.item.selectable:hover {
+                color: #292b2c;
+            }
         }
     }
 

--- a/src/lib/css/plex-modal.scss
+++ b/src/lib/css/plex-modal.scss
@@ -3,113 +3,114 @@ $sizes: (
     md: 50vw,
     lg: 80vw,
 );
+plex-modal {
+    .plex-modal {
+        position: fixed;
+        width: 100vw;
+        background-color: rgba(0, 0, 0, 0.6);
+        z-index: 1100;
+        height: 100vh;
+        top: 0;
+        left: 0;
 
-.plex-modal {
-    position: fixed;
-    width: 100vw;
-    background-color: rgba(0, 0, 0, 0.6);
-    z-index: 1100;
-    height: 100vh;
-    top: 0;
-    left: 0;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    animation: present-modal 0.15s ease-in;
-
-    .plex-modal-close {
-        position: relative;
-        cursor: pointer;
         display: flex;
-        justify-content: flex-end;
-        left: 18px;
-        top: 10px;
-    }
+        justify-content: center;
+        align-items: center;
 
-    header {
-        position: relative;
-        padding: 1rem;
-    }
+        animation: present-modal 0.15s ease-in;
 
-    .plex-modal-content {
-        background-color: white;
-        min-width: 375px;
-        max-width: 90vw;
-        margin: auto;
-        transition: opacity;
-        padding: 0 2rem;
-
-        main {
+        .plex-modal-close {
+            position: relative;
+            cursor: pointer;
             display: flex;
-            justify-content: center;
-            margin: 10px 0;
-            min-height: 25vh;
+            justify-content: flex-end;
+            left: 18px;
+            top: 10px;
         }
 
-        @each $size, $length in $sizes {
-            &.#{$size} {
-                width: $length;
-                @if $size == md {
-                    main {
-                        max-height: 50vh;
-                        padding: 0 0.5rem;
-                        overflow-y: scroll;
+        header {
+            position: relative;
+            padding: 1rem;
+        }
+
+        .plex-modal-content {
+            background-color: white;
+            min-width: 375px;
+            max-width: 90vw;
+            margin: auto;
+            transition: opacity;
+            padding: 0 2rem;
+
+            main {
+                display: flex;
+                justify-content: center;
+                margin: 10px 0;
+                min-height: 25vh;
+            }
+
+            @each $size, $length in $sizes {
+                &.#{$size} {
+                    width: $length;
+                    @if $size == md {
+                        main {
+                            max-height: 50vh;
+                            padding: 0 0.5rem;
+                            overflow-y: scroll;
+                        }
                     }
                 }
             }
         }
-    }
 
-    header {
-        plex-icon {
-            display: flex;
-            align-items: center;
-            justify-content: center;
+        header {
+            plex-icon {
+                display: flex;
+                align-items: center;
+                justify-content: center;
 
-            i {
-                font-size: 4rem;
-            }
-            &[name="close"] {
                 i {
-                    font-size: 1rem;
+                    font-size: 4rem;
+                }
+                &[name="close"] {
+                    i {
+                        font-size: 1rem;
+                    }
                 }
             }
+
+            plex-modal-title {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 2rem;
+                font-weight: bold;
+                color: gray;
+            }
+
+            plex-modal-subtitle {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 1.5rem;
+            }
         }
 
-        plex-modal-title {
+        footer {
             display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 2rem;
-            font-weight: bold;
-            color: gray;
-        }
-
-        plex-modal-subtitle {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 1.5rem;
+            justify-content: space-between;
+            align-items: flex-end;
+            padding: 16px 0;
+            margin: 0;
         }
     }
 
-    footer {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-end;
-        padding: 16px 0;
-        margin: 0;
-    }
-}
+    @keyframes present-modal {
+        0% {
+            opacity: 0;
+        }
 
-@keyframes present-modal {
-    0% {
-        opacity: 0;
-    }
-
-    100% {
-        opacity: 1;
+        100% {
+            opacity: 1;
+        }
     }
 }

--- a/src/lib/modal/modal.component.ts
+++ b/src/lib/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, HostListener, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, HostListener, Output, EventEmitter, OnInit, ViewEncapsulation } from '@angular/core';
 import { PlexSize } from '../core/plex-size.type';
 
 


### PR DESCRIPTION
- Algunas clases de invert se estaban filtrando dentro de otros componentes, generando situaciones indeseadas.
- Se actualizó demo en `/modal` confirmando esta funcionalidad