### PR TITLE
plex-tabs: agrega atributos de accesibilidad

### DIFF
--- a/cypress/integration/tabs.js
+++ b/cypress/integration/tabs.js
@@ -4,7 +4,16 @@ context('tabs', () => {
     before(() => {
         cy.eyesOpen({ appName: 'PLEX', testName: 'plex-tabs' });
         cy.visit('/tabs');
+        cy.injectAxe();
+        cy.eyesCheckWindow('start - tabs');
     });
+
+    it.skip('No tiene problemas de A11y en la carga inicial', () => {
+        // Test de pantalla inicial
+        cy.checkA11y(null, {
+            includedImpacts: ['critical']
+        });
+    })
 
     it('navega tabs', () => {
 
@@ -21,6 +30,5 @@ context('tabs', () => {
         cy.get('plex-layout plex-tabs:first').find('plex-tab').eq(2).contains('Contenido 3');
 
         cy.eyesClose();
-
     });
 });

--- a/src/demo/app/tabs/tabs.html
+++ b/src/demo/app/tabs/tabs.html
@@ -24,9 +24,11 @@
                 </plex-tab>
                 <plex-dropdown label="hola" size="sm" [items]="items" right="false">
                 </plex-dropdown>
-                <plex-button type="info" size="sm" title="anterior" icon="chevron-left" (click)="previous()">
+                <plex-button type="info" size="sm" title="anterior" icon="chevron-left"
+                             ariaLabel="navegar tab hacia la izquierda" (click)="previous()">
                 </plex-button>
-                <plex-button type="info" size="sm" title="siguiente" icon="chevron-right" (click)="next()">
+                <plex-button type="info" size="sm" title="siguiente" icon="chevron-right"
+                             ariaLabel="navegar tab hacia la derecha" (click)="next()">
                 </plex-button>
             </plex-tabs>
         </section>
@@ -83,7 +85,8 @@
                     <b>Tercera pestaña.</b>Generalmente utilizado como panel para listados de historiales.
                 </div>
             </plex-tab>
-            <plex-button type="danger" size="sm" icon="close" title="prueba sidebar"></plex-button>
+            <plex-button type="danger" size="sm" icon="close" ariaLabel="cerrar panel lateral" title="prueba sidebar">
+            </plex-button>
         </plex-tabs>
     </plex-layout-sidebar>
 </plex-layout>

--- a/src/lib/tabs/tab.component.ts
+++ b/src/lib/tabs/tab.component.ts
@@ -2,7 +2,9 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
     selector: 'plex-tab',
-    template: `<ng-content *ngIf='active'></ng-content>`,
+    template: `<div tabindex="0" role="tabpanel" id="{{ label }}" attr.aria-labelledby="{{ label }}">
+                    <ng-content *ngIf='active'></ng-content>
+                </div>`,
 })
 export class PlexTabComponent {
 

--- a/src/lib/tabs/tab.component.ts
+++ b/src/lib/tabs/tab.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
     selector: 'plex-tab',
-    template: `<div tabindex="0" role="tabpanel" id="{{ label }}" attr.aria-labelledby="{{ label }}">
+    template: `<div tabindex="0" role="tabpanel">
                     <ng-content *ngIf='active'></ng-content>
                 </div>`,
 })

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -5,13 +5,13 @@ import { PlexTabComponent } from './tab.component';
     selector: 'plex-tabs',
     template: ` <section justify>
                     <ul role="tablist" #container class="nav nav-tabs" [ngClass]="size" >
-                        <li role="presentation" *ngFor="let tab of tabs" (keydown.enter)="selectTab(tab, $event)" (click)="selectTab(tab, $event)" (auxclick)="closeTab(tab, $event)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
-                            <a tabindex="0" role="tab" attr.aria-selected="{{ tab.active }}" attr.aria-label="{{ tab.label }}" class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
-                                <plex-icon *ngIf="tab.icon" [name]="tab.icon" size="sm" [type]="tab.color"></plex-icon>
+                        <li role="presentation" *ngFor="let tab of tabs" (keydown.arrowright)="nextTab()" (keydown.arrowleft)="prevTab()" (keydown.enter)="selectTab(tab, $event)" (click)="selectTab(tab, $event)" (auxclick)="closeTab(tab, $event)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
+                        <a tabindex="{{ tab.active ? '0' : '-1' }}" role="tab" attr.aria-selected="{{ tab.active }}" attr.aria-label="{{ tab.label }}" attr.aria-controls="{{ tab.label }}" id="{{ tab.label }}" class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
+                        <plex-icon *ngIf="tab.icon" [name]="tab.icon" size="sm" [type]="tab.color"></plex-icon>
                                 <span *ngIf="tab.label">
                                     {{ tab.label  }}
                                 </span>
-                                <button *ngIf="tab.allowClose" attr.aria-label="cerrar pestaña" type="button" class="close" (click)="closeTab(tab)"><i class="mdi mdi-close"></i></button>
+                                <button *ngIf="tab.allowClose" aria-label="cerrar pestaña" type="button" class="close" (click)="closeTab(tab)"><i class="mdi mdi-close"></i></button>
                             </a>
                         </li>
                     </ul>
@@ -74,9 +74,38 @@ export class PlexTabsComponent implements AfterContentInit {
     }
 
     // Accesibilidad
+    private nextTab(event) {
+        this._activeIndex++;
+        if (this._activeIndex < this.tabs.length - 1) {
+            this._activeIndex = this._activeIndex;
+        }
+
+        else {
+            this._activeIndex = this.tabs.length - 1;
+        };
+
+        this.doActiveTab(this._activeIndex);
+        console.log(this.tabs.length);
+    }
+
+    private prevTab(event) {
+        if (this._activeIndex > 0) {
+            this._activeIndex = this._activeIndex - 1;
+        }
+        this.doActiveTab(this._activeIndex);
+    }
+
     onKeydown(event) {
         if (event.key === "enter") {
             this.doActiveTab(event);
+        }
+
+        if (event.key === "arrowright") {
+            this.nextTab(event);
+        }
+
+        if (event.key === "arrowleft") {
+            this.prevTab(event);
         }
     }
 

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, Input, Output, EventEmitter, ContentChild, ContentChildren, ViewChildren, forwardRef, QueryList, ElementRef, AfterContentInit, ViewChild } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ContentChildren, QueryList, ElementRef, AfterContentInit, ViewChild } from '@angular/core';
 import { PlexTabComponent } from './tab.component';
 
 @Component({
@@ -6,7 +6,7 @@ import { PlexTabComponent } from './tab.component';
     template: ` <section justify>
                     <ul role="tablist" #container class="nav nav-tabs" [ngClass]="size" >
                         <li role="presentation" *ngFor="let tab of tabs" (keydown.arrowright)="nextTab()" (keydown.arrowleft)="prevTab()" (keydown.enter)="selectTab(tab, $event)" (click)="selectTab(tab, $event)" (auxclick)="closeTab(tab, $event)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
-                        <a tabindex="{{ tab.active ? '0' : '-1' }}" role="tab" attr.aria-selected="{{ tab.active }}" attr.aria-label="{{ tab.label }}" attr.aria-controls="{{ tab.label }}" id="{{ tab.label }}" class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
+                        <a [tabindex]="tab.active ? '0' : '-1'" role="tab" [attr.aria-selected]="tab.active" [attr.aria-label]="tab.label" [id]="tab.label" class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
                         <plex-icon *ngIf="tab.icon" [name]="tab.icon" size="sm" [type]="tab.color"></plex-icon>
                                 <span *ngIf="tab.label">
                                     {{ tab.label  }}
@@ -78,14 +78,10 @@ export class PlexTabsComponent implements AfterContentInit {
         this._activeIndex++;
         if (this._activeIndex < this.tabs.length - 1) {
             this._activeIndex = this._activeIndex;
-        }
-
-        else {
+        } else {
             this._activeIndex = this.tabs.length - 1;
-        };
-
+        }
         this.doActiveTab(this._activeIndex);
-        console.log(this.tabs.length);
     }
 
     private prevTab(event) {
@@ -96,15 +92,15 @@ export class PlexTabsComponent implements AfterContentInit {
     }
 
     onKeydown(event) {
-        if (event.key === "enter") {
+        if (event.key === 'enter') {
             this.doActiveTab(event);
         }
 
-        if (event.key === "arrowright") {
+        if (event.key === 'arrowright') {
             this.nextTab(event);
         }
 
-        if (event.key === "arrowleft") {
+        if (event.key === 'arrowleft') {
             this.prevTab(event);
         }
     }

--- a/src/lib/tabs/tabs.component.ts
+++ b/src/lib/tabs/tabs.component.ts
@@ -4,14 +4,14 @@ import { PlexTabComponent } from './tab.component';
 @Component({
     selector: 'plex-tabs',
     template: ` <section justify>
-                    <ul #container class="nav nav-tabs" [ngClass]="size">
-                        <li *ngFor="let tab of tabs" (click)="selectTab(tab, $event)" (auxclick)="closeTab(tab, $event)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
-                            <a class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
+                    <ul role="tablist" #container class="nav nav-tabs" [ngClass]="size" >
+                        <li role="presentation" *ngFor="let tab of tabs" (keydown.enter)="selectTab(tab, $event)" (click)="selectTab(tab, $event)" (auxclick)="closeTab(tab, $event)" class="nav-item nav-item-{{tab.color}}" [ngClass]="{'active': tab.active, 'icon': tab.icon && !tab.label}">
+                            <a tabindex="0" role="tab" attr.aria-selected="{{ tab.active }}" attr.aria-label="{{ tab.label }}" class="nav-link" [ngClass]="{active: tab.active}" plexRipples onclick="return false">
                                 <plex-icon *ngIf="tab.icon" [name]="tab.icon" size="sm" [type]="tab.color"></plex-icon>
                                 <span *ngIf="tab.label">
                                     {{ tab.label  }}
                                 </span>
-                                <button *ngIf="tab.allowClose" type="button" class="close" (click)="closeTab(tab)"><i class="mdi mdi-close"></i></button>
+                                <button *ngIf="tab.allowClose" attr.aria-label="cerrar pestaña" type="button" class="close" (click)="closeTab(tab)"><i class="mdi mdi-close"></i></button>
                             </a>
                         </li>
                     </ul>
@@ -70,6 +70,13 @@ export class PlexTabsComponent implements AfterContentInit {
     closeTab(tab: PlexTabComponent, $event = null) {
         if (!$event || ($event.button === 1 && tab.allowClose)) {
             this.close.emit(this.tabs.indexOf(tab));
+        }
+    }
+
+    // Accesibilidad
+    onKeydown(event) {
+        if (event.key === "enter") {
+            this.doActiveTab(event);
         }
     }
 


### PR DESCRIPTION
**1. Se agregan roles correspondientes**
⦁ `role="tablist"` al contenedor de las tabs (otorga semántica al elemento, detectando la cantidad de pestañas)
⦁ `role="tab"` al elementos tabeable de la pestaña (identifica al `<li>` como pestaña)
⦁ `role="presentation"` para que el screen reader ignore la semantica de la `<ul>` (que no diga lista, que diga lista de pestañas)

**2. Se agregan arias correspondientes**
⦁ aria-selected _(screen reader menciona la pestaña activa)_
⦁ aria-label _(screen reader menciona descripción del título y botones "cerrar")_

**3. Se agrega funcionalidad accesible por teclado**
⦁ focusable con tab
⦁ navegación con arrows _(flechitas)_
 
**Plus:** se agrega test de cypress al componente

**Para testear:** 
Tabear hasta llegar a las tabs y navegarlas mediante flechas. 
El orden de navegación debería ser: tab-header > tab-body > siguiente tab-header > siguiente tab-body (salvo casos con botoneras)

![Plex-Tabs](https://user-images.githubusercontent.com/5895886/118516933-29486400-b70d-11eb-878b-74dabc49383e.gif)
