### PR TITLE
fix(hint): accesible en mobile

### DIFF
--- a/cypress/integration/directiva-hint.js
+++ b/cypress/integration/directiva-hint.js
@@ -11,12 +11,12 @@ context('directive hint', () => {
     it('hint directive content', () => {
         const hintText = '¿Sabías que... el hint es un texto que sugiere acciones o indica alguna novedad?';
         cy.get('#cdk-describedby-message-container div').eq(0).should('not.be.visible');
-        cy.get('plex-hint').eq(0).find('a').focus().trigger('mouseover', { force: true });
+        cy.get('plex-hint').eq(0).find('span').focus().trigger('mouseover', { force: true });
         cy.get('#cdk-describedby-message-container div').eq(0).should('contain', hintText);
     });
 
     it.only('hint directive click', () => {
-        cy.get('plex-hint').eq(0).find('a').focus().trigger('click', { force: true });
+        cy.get('plex-hint').eq(0).find('span').focus().trigger('click', { force: true });
         cy.get('div.hint-click-test').should('contain', '¿Cuántos clicks fallidos hace uno en la vida?');
     });
 

--- a/cypress/integration/directiva-hint.js
+++ b/cypress/integration/directiva-hint.js
@@ -15,7 +15,7 @@ context('directive hint', () => {
         cy.get('#cdk-describedby-message-container div').eq(0).should('contain', hintText);
     });
 
-    it.only('hint directive click', () => {
+    it('hint directive click', () => {
         cy.get('plex-hint').eq(0).find('span').focus().trigger('click', { force: true });
         cy.get('div.hint-click-test').should('contain', '¿Cuántos clicks fallidos hace uno en la vida?');
     });

--- a/cypress/integration/select.js
+++ b/cypress/integration/select.js
@@ -1,12 +1,12 @@
 /// <reference types="Cypress" />
 
-context('select', () => {
+context('<plex-select>', () => {
     before(() => {
         cy.eyesOpen({ appName: 'PLEX', testName: 'select' });
         cy.visit('/select');
     });
 
-    it('test accordion', () => {
+    it('Casos de selección simple y búsqueda', () => {
 
         cy.server();
         cy.route('GET', '**/api/core/tm/paises?nombre=brasil', [{

--- a/src/lib/css/hint.scss
+++ b/src/lib/css/hint.scss
@@ -1,4 +1,5 @@
 plex-hint {
+    width: 8px;
     .hint-container {
         @include position(relative);
         &.detach-both {

--- a/src/lib/css/plex-hint.scss
+++ b/src/lib/css/plex-hint.scss
@@ -1,3 +1,0 @@
-plex-hint {
-    width: 8px;
-}

--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -5,8 +5,8 @@ import { PlexType } from '../core/plex-type.type';
 @Component({
     selector: 'plex-hint',
     template: `
-        <span #matTooltip="matTooltip" tabindex="0" *ngIf="position && content" class="hint-container detach-{{detach}}" 
-        [matTooltip]="content" [matTooltipPosition]="position" (click)="showTooltip()">
+        <span #matTooltip="matTooltip" tabindex="0" *ngIf="position && content" class="hint-container detach-{{detach}}"
+            [matTooltip]="content" [matTooltipPosition]="position" (click)="showTooltip()">
             <plex-icon class="hint {{ hintType }}" [name]="hintIcon" size="xs" type="light"></plex-icon>
         </span>
     `

--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -5,7 +5,7 @@ import { PlexType } from '../core/plex-type.type';
 @Component({
     selector: 'plex-hint',
     template: `
-        <span #matTooltip="matTooltip" tabindex="0" *ngIf="position && content" class="hint-container detach-{{detach}}"
+        <span #matTooltip="matTooltip" tabindex="0" role="link" *ngIf="position && content" class="hint-container detach-{{detach}}"
             [matTooltip]="content" [matTooltipPosition]="position" (click)="showTooltip()">
             <plex-icon class="hint {{ hintType }}" [name]="hintIcon" size="xs" type="light"></plex-icon>
         </span>

--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -4,9 +4,9 @@ import { PlexType } from '../core/plex-type.type';
 @Component({
     selector: 'plex-hint',
     template: `
-        <a href="javascript:void(0)" *ngIf="position && content" class="hint-container detach-{{detach}}" [matTooltip]="content" [matTooltipPosition]="position">
+        <span tabindex="0" *ngIf="position && content" class="hint-container detach-{{detach}}" [matTooltip]="content" [matTooltipPosition]="position" [matTooltipShowDelay]="0">
             <plex-icon class="hint {{ hintType }}" [name]="hintIcon" size="xs" type="light"></plex-icon>
-        </a>
+        </span>
     `
 })
 export class HintComponent implements OnInit {

--- a/src/lib/hint/hint.component.ts
+++ b/src/lib/hint/hint.component.ts
@@ -1,10 +1,12 @@
-import { Component, OnInit, Input, HostListener } from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
+import { Component, OnInit, Input, HostListener, ViewChild } from '@angular/core';
 import { PlexType } from '../core/plex-type.type';
 
 @Component({
     selector: 'plex-hint',
     template: `
-        <span tabindex="0" *ngIf="position && content" class="hint-container detach-{{detach}}" [matTooltip]="content" [matTooltipPosition]="position" [matTooltipShowDelay]="0">
+        <span #matTooltip="matTooltip" tabindex="0" *ngIf="position && content" class="hint-container detach-{{detach}}" 
+        [matTooltip]="content" [matTooltipPosition]="position" (click)="showTooltip()">
             <plex-icon class="hint {{ hintType }}" [name]="hintIcon" size="xs" type="light"></plex-icon>
         </span>
     `
@@ -31,8 +33,14 @@ export class HintComponent implements OnInit {
 
     constructor() { }
 
+    @ViewChild('matTooltip', { static: false }) matTooltip: MatTooltip;
+
     ngOnInit() {
         this.position = 'above';
+    }
+
+    showTooltip() {
+        this.matTooltip.show(0);
     }
 
     // Si el elemento que tiene la directiva [hint] tiene un evento (click), este se ejecutará, guste o no.

--- a/src/lib/styles.scss
+++ b/src/lib/styles.scss
@@ -57,7 +57,7 @@
 $typoPRO-font-path: "~@andes/plex/src/lib/css/fonts/" !default;
 @import "css/fonts/TypoPRO-SourceSansPro";
 
-$mdi-font-path: "~@mdi/font/fonts/";	
+$mdi-font-path: "~@mdi/font/fonts/";
 @import "~@mdi/font/scss/materialdesignicons";
 
 // Misc
@@ -103,7 +103,6 @@ $mdi-font-path: "~@mdi/font/fonts/";
 @import "css/plex-label";
 @import "css/plex-title";
 @import "css/plex-help";
-@import "css/plex-hint";
 @import "css/plex-modal";
 @import "css/plex-detail";
 @import "css/plex-options";


### PR DESCRIPTION
Se encontró que el hint aunque es funcional en mobile, al usar un tag `<a>` algunos navegadores interpretan que el usuario quiere abrir un link en una nueva pestaña. 
Se reemplazó por un tag `<span>` con `tabindex="0"`

```html
<span tabindex="0" *ngIf="position && content" class="hint-container detach-{{detach}}" [matTooltip]="content" [matTooltipPosition]="position" [matTooltipShowDelay]="0">
        <plex-icon class="hint {{ hintType }}" [name]="hintIcon" size="xs" type="light"></plex-icon>
</span>
```