### PR TITLE
fix(plex-badge): resuelve hover en invert + alineación badge-btn

### DIFF
--- a/src/demo/app/button/button.html
+++ b/src/demo/app/button/button.html
@@ -44,7 +44,7 @@
             </div>
         </form>
     </plex-layout-main>
-    <plex-layout-sidebar>
+    <plex-layout-sidebar type="invert">
         <plex-title titulo="plex-badge: types"></plex-title>
         <plex-title size="sm" titulo="badge normal"></plex-title>
         <plex-badge size="sm" type="success" class="mr-1">VALIDADO</plex-badge>

--- a/src/lib/css/plex-accordion.scss
+++ b/src/lib/css/plex-accordion.scss
@@ -24,12 +24,12 @@ plex-accordion {
     .title,
     > div {
       width: 100%;
-      &:hover,
-      :focus {
-        color: $blue;
-      }
+          &:hover, &:focus:not(plex-button) {
+            color: $blue;
+        }  
     }
   }
+  
   [plex-accordion-title] {
     width: 100%;
     display: flex;

--- a/src/lib/css/plex-badge.scss
+++ b/src/lib/css/plex-badge.scss
@@ -52,7 +52,6 @@ plex-badge {
         border-color: var(--badge-color);
         &:hover {
             background-color: var(--badge-color);
-            mix-blend-mode: darken;
             opacity: 0.75;
         }
     }

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -99,7 +99,6 @@ plex-help {
 
     plex-button {
       position: relative;
-      top: 1px;
       right: 0;
       display: flex;
       justify-content: flex-end;

--- a/src/lib/css/plex-item.scss
+++ b/src/lib/css/plex-item.scss
@@ -313,6 +313,10 @@ plex-list {
         upload-file {
             margin: 0 0.15rem;
         }
+        
+        .btn-badge > plex-button {
+            margin: 0;
+        }
 
         .dropdown .btn {
             padding: 0.25rem 0.2rem;


### PR DESCRIPTION
**Task**
https://proyectos.andes.gob.ar/browse/PLEX-255

**Problemas**
1. plex-badge con button incorporado se pierde en estado :hover + separación del botón respecto al badge.
2. En contexto de plex-help, se perciben desalineados los plex-buttons en relación al resto de los elementos.

**Soluciones**
1. Se quita propiedad mix-blend del estado :hover del plex-button incorporados dentro de plex-badges.
2. Se remueve la propiedad top: 1px, existente en estilos de buttons presentes en botonera del plex-item.

**Plus**
Se resuelve herencia indeseada en plex-accordion
https://proyectos.andes.gob.ar/browse/PLEX-282

