### PR TITLE
Plex-Accordion: nueva directiva plAccordion

### DIFF
--- a/src/lib/accordion/panel.component.ts
+++ b/src/lib/accordion/panel.component.ts
@@ -33,7 +33,7 @@ export class PlexPanelComponent {
     @Input() icon: string;
     @Input() content: string;
     @Input() active: boolean;
-    @Output() toggle = new EventEmitter();
+    @Output() toggle = new EventEmitter<boolean>();
 
     constructor(accordion: PlexAccordionComponent) {
         accordion.addPanel(this);

--- a/src/lib/accordion/pl-accordion.directive.ts
+++ b/src/lib/accordion/pl-accordion.directive.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectorRef, Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+import { interval, NEVER, Subscription, merge } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { PlexPanelComponent } from './panel.component';
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[plAccordion]'
+})
+
+export class AccordionDirective implements OnInit, OnDestroy {
+    private openSubscription: Subscription;
+    private viewRef: any = null;
+
+    // En el caso que se indique una cantidad de milisegundos, se renderiza al cumplirse el tiempo ingresado.
+    @Input() plAccordion: number;
+
+    constructor(
+        private view: ViewContainerRef,
+        private nextRef: TemplateRef<any>,
+        private plexPanel: PlexPanelComponent,
+        private changes: ChangeDetectorRef,
+    ) { }
+
+    ngOnInit() {
+        const timer = this.plAccordion ? interval(this.plAccordion) : NEVER;
+        this.openSubscription = merge(
+            this.plexPanel.toggle.pipe(filter(active => active)),
+            timer
+        ).subscribe(() => {
+            if (!this.viewRef) {
+                this.viewRef = this.view.createEmbeddedView(this.nextRef);
+                this.changes.markForCheck();
+                this.openSubscription.unsubscribe();
+            }
+        });
+    }
+
+    ngOnDestroy() {
+        this.openSubscription.unsubscribe();
+    }
+}

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -84,6 +84,7 @@ import { PlexTableColumnsComponent } from './table/table-column-dropdown.compone
 import { PlexTableColDirective } from './table/display-column.directive';
 import { PlexTableSortPipe } from './table/table-sort.pipe';
 import { PlexColumnDirective } from './table/columns.directive';
+import { AccordionDirective } from './accordion/pl-accordion.directive';
 import { PlexVisualizadorService } from './core/plex-visualizador.service';
 
 @NgModule({
@@ -165,6 +166,7 @@ import { PlexVisualizadorService } from './core/plex-visualizador.service';
         TooltipContentComponent,
         HintComponent,
         MobileDirective,
+        AccordionDirective,
 
         // EXTRAS - NO CORRER DE ACA
         ValidationMessagesComponent,
@@ -242,6 +244,7 @@ import { PlexVisualizadorService } from './core/plex-visualizador.service';
         MobileDirective,
         PlexTableColDirective,
         PlexColumnDirective,
+        AccordionDirective
     ],
     providers: [
         TitleCasePipe,


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/PLEX-291

### Funcionalidad desarrollada 
Se agrega nueva directiva plAccordion

<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agregó la nueva directiva plAccordion que renderiza el contenido una vez que se encuentra activa. Se puede enviar a la una cantidad de tiempo para que se retrase la carga aunque no este activo el panel.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

