### PR TITLE
feat(plex-label): posibilita custom-colors

### DIFF
--- a/src/demo/app/label/label.component.ts
+++ b/src/demo/app/label/label.component.ts
@@ -8,7 +8,6 @@ export class LabelDemoComponent {
 
     foto = true;
     icon = false;
-
     icono = {
         caracter: 'pencil',
         color: 'info',
@@ -26,9 +25,10 @@ export class LabelDemoComponent {
     ];
 
     pasos = [
-        { label: 'A', valor: 'Ingrese al menos tres caracteres. Si la búsqueda no arroja el resultado esperado, presione el botón "Paciente Nuevo".', type: 'Busque un paciente' },
-        { label: 'B', valor: 'La selección se realiza desde los campos desplegables que se encuentran sobre el calendario de agendas.', type: 'Seleccione prestación' },
-        { label: 'C', valor: 'Una vez seleccionado el profesional y la prestación, podrá visualizar las opciones de bloques y horarios.', type: 'Confirme horario' },
+        { label: 'A', valor: 'Ingrese al menos tres caracteres. Si la búsqueda no arroja el resultado esperado, presione el botón "Paciente Nuevo".', titulo: 'Busque un paciente', subtitulo: 'Alteración que se produce en el desarrollo normal de un proceso', semantic: 'Trastorno', icono: 'trastorno', color: '#ff4a1a' },
+        { label: 'B', valor: 'La selección se realiza desde los campos desplegables que se encuentran sobre el calendario de agendas.', titulo: 'Seleccione prestación', subtitulo: 'Procedimiento, entidad observable, régimen/tratamiento', semantic: 'Procedimiento', icono: 'termometro', color: '#92278e' },
+        { label: 'C', valor: 'Una vez seleccionado el profesional y la prestación, podrá visualizar las opciones de bloques y horarios.', titulo: 'Confirme horario', subtitulo: 'Producto, objeto físico, medicamento clínico, fármaco de uso clínico', semantic: 'Producto', icono: 'pildoras', color: '#00bcb4' },
+        { label: 'D', valor: '', titulo: '', subtitulo: 'Pedidos realizados desde un efector, sector o servicio', semantic: 'Solicitudes', icono: 'mano-corazon', color: '#0070cc' }
     ];
 
     eventos = [

--- a/src/demo/app/label/label.html
+++ b/src/demo/app/label/label.html
@@ -10,18 +10,27 @@
                 </div>
                 <plex-title titulo="Pasos explicativos" size="sm"></plex-title>
                 <div justify="center" class="h-50">
-                    <plex-label *ngFor="let nodo of pasos" type="info" size="lg" direction="column"
-                                titulo="{{ nodo.type }}" subtitulo="{{ nodo.valor }}">
+                    <plex-label *ngFor="let nodo of pasos | slice:0:3" size="lg" direction="column"
+                                titulo="{{ nodo.titulo }}" subtitulo="{{ nodo.valor }}">
                         <p dato>{{ nodo.label }}</p>
                     </plex-label>
                 </div>
             </section>
-            <section class="ml-4 d-flex flex-column justify-content-betweeen h-100">
-                <plex-title titulo="Cronología"></plex-title>
-                <plex-label *ngFor="let fecha of eventos" type="info" size="md" direction="row"
-                            titulo="{{ fecha.type }}" subtitulo="{{ fecha.valor }}">
-                    <p dato>{{ fecha.label }}</p>
-                </plex-label>
+            <section class="mx-4 d-flex flex-column justify-content-betweeen h-100">
+                <div>
+                    <plex-title titulo="Cronología"></plex-title>
+                    <plex-label *ngFor="let fecha of eventos | slice:0:3" type="info" size="md" direction="row"
+                                titulo="{{ fecha.type }}" subtitulo="{{ fecha.valor }}">
+                        <p dato>{{ fecha.label }}</p>
+                    </plex-label>
+                </div>
+                <div>
+                    <plex-title titulo="Custom colors" size="sm"></plex-title>
+                    <plex-label *ngFor="let paso of pasos" [color]="paso.color" case="capitalize-first" size="md"
+                                icon="{{ paso.icono }}" direction="row" titulo="{{ paso.semantic }}"
+                                subtitulo="{{ paso.subtitulo }}">
+                    </plex-label>
+                </div>
             </section>
         </plex-grid>
     </plex-layout-main>

--- a/src/lib/css/plex-label.scss
+++ b/src/lib/css/plex-label.scss
@@ -3,7 +3,7 @@
     --font-size-sm: .75rem;
     --font-size-md: .9rem;
     --font-size-lg: 1.05rem;
-    --font-size-xl: 1.25rem;
+    --font-size-xl: 1.25rem; 
     
     &.sm {
         font-size: var(--font-size-sm);
@@ -33,6 +33,7 @@
         border-radius: 50%;
         padding: 5px 7px;
         margin: 0 .75rem;
+        color: var(--label-color);
     }
 
     section {

--- a/src/lib/label/label.component.ts
+++ b/src/lib/label/label.component.ts
@@ -1,21 +1,21 @@
-import { Component, Input, ElementRef, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, OnChanges, ViewChild } from '@angular/core';
 
 @Component({
     selector: 'plex-label',
     template: `
-    <div class="plex-label {{ size }} d-flex flex-{{direction}}" [ngClass]="{ 'align-items-center': direction === 'column' }">
-    <plex-icon *ngIf="icon && !datos" name="{{icon}}" class="text-{{ type }}"></plex-icon>
-    <ng-content select="plex-icon"></ng-content>
-    <ng-content select="[dato]"></ng-content>
-    <div class="d-flex flex-column" [ngClass]="direction === 'column' ? 'align-items-center mt-2 px-4' : ''">
-        <span *ngIf="titulo" class="text-{{ type }}" [ngClass]="{'font-weight-bold': tituloBold}">{{ titulo }}</span>
-        <small *ngIf="titulo && subtitulo" class="">{{ subtitulo }}</small>
+    <div #labelColor class="plex-label {{ size }} d-flex flex-{{direction}}" [ngClass]="{ 'align-items-center': direction === 'column' }">
+        <plex-icon *ngIf="icon && !datos" name="{{icon}}" class="text-{{ type }}"></plex-icon>
+        <ng-content select="plex-icon"></ng-content>
+        <ng-content select="[dato]"></ng-content>
+        <div class="d-flex flex-column" [ngClass]="direction === 'column' ? 'align-items-center mt-2 px-4' : ''">
+            <span *ngIf="titulo" class="text-{{ type }}" [ngClass]="{'font-weight-bold': tituloBold}">{{ titulo }}</span>
+            <small *ngIf="titulo && subtitulo" class="">{{ subtitulo }}</small>
+        </div>
+        <ng-content *ngIf="!titulo && !subtitulo"></ng-content>
     </div>
-    <ng-content *ngIf="!titulo && !subtitulo"></ng-content>
-</div>
     `
 })
-export class PlexLabelComponent implements AfterViewInit {
+export class PlexLabelComponent implements AfterViewInit, OnChanges {
     @Input() titulo: string;
     @Input() tituloBold = true;
     @Input() subtitulo: string;
@@ -24,11 +24,20 @@ export class PlexLabelComponent implements AfterViewInit {
     @Input() dato: string;
     @Input() direction: 'column' | 'row' = 'row';
     @Input() type: 'success' | 'info' | 'warning' | 'danger' | 'default';
+    @Input() color: string;
+
+    @ViewChild('labelColor', { static: true }) labelColor: ElementRef;
 
     public datos = false;
 
     ngAfterViewInit() {
         this.datos = !!this.datRef.nativeElement.querySelector('[dato]');
+    }
+
+    ngOnChanges() {
+        if (this.color && this.color.length > 0) {
+            this.labelColor.nativeElement.style.setProperty('--label-color', this.color);
+        }
     }
 
     constructor(private datRef: ElementRef) { }


### PR DESCRIPTION
**Tarea**
https://proyectos.andes.gob.ar/browse/PLEX-226

**Situación de uso**
Diferenciar elementos de un listado

**Criterio de aceptación**
El color se configura mediante el selector de la propiedad [color].
Que el color se apliqué sólo al icono.

**Plus**
Se actualiza demo con caso de uso (ver adjunto).

![plex-label-custom-colors](https://user-images.githubusercontent.com/5895886/130063574-4c01b9ed-a723-41a4-b112-3c06f7ebe73e.PNG)
