### PR TITLE
fix(plex-table): implementa sorteable: false

### DIFF
--- a/src/demo/app/table/table.ts
+++ b/src/demo/app/table/table.ts
@@ -81,9 +81,8 @@ export class TableDemoComponent {
         {
             key: 'col-4',
             label: 'col 4',
-            sorteable: true,
+            sorteable: false,
             opcional: true,
-            sort: (a: any, b: any) => a.fecha.getTime() - b.fecha.getTime()
         },
         {
             key: 'col-5',

--- a/src/lib/table/columns.directive.ts
+++ b/src/lib/table/columns.directive.ts
@@ -72,6 +72,11 @@ export class PlexColumnDirective implements OnChanges, OnDestroy {
     }
 
     onColumnClick(column: IPlexTableColumns) {
+
+        if (!column.sorteable) {
+            return false;
+        }
+
         const data = this._sort.getValue();
 
         if (data.sortBy === column.key) {


### PR DESCRIPTION
Una columna con la propiedad `sortable: false` provoca un error interno en el componente porque no hay comprobación sobre esta propiedad, ya que se intenta llamar a la función `sort` del componente.