### PR TITLE
Mejoras en plex-help (alto automático y color types)

### DIFF
--- a/src/demo/app/help/help.html
+++ b/src/demo/app/help/help.html
@@ -151,7 +151,8 @@
 
         <plex-title titulo="plex-help (type ='info')" size="sm">
             <plex-button size="sm" type="success" label="acción satisfactoria"></plex-button>
-            <plex-help titulo="Información sobre este panel" subtitulo="A continuación los pasos a seguir">
+            <plex-help titulo="Información sobre este panel" subtitulo="A continuación los pasos a seguir"
+                       btnType="success">
                 <ol info class="list-group-flush">
                     <li>Buscá conceptos SNOMED en el campo de texto del panel lateral
                         (acepta búsquedas

--- a/src/lib/css/plex-help.scss
+++ b/src/lib/css/plex-help.scss
@@ -52,6 +52,12 @@ plex-help {
       overflow-y: scroll;
       max-height: 70vh;
     }
+    &.auto {
+      width: auto;
+      height: auto;
+      overflow-x: hidden;
+      overflow-y: scroll;
+    }
 
     // @Input() titulo:
     .card-header {

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -1,5 +1,5 @@
+import { Component, ElementRef, EventEmitter, Input, Output, Renderer2 } from '@angular/core';
 import { PlexType } from './../core/plex-type.type';
-import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@angular/core';
 
 @Component({
     selector: 'plex-help',
@@ -65,9 +65,8 @@ export class PlexHelpComponent {
         if (!this.closed) {
 
             setTimeout(() => {
-                const toggleDiv = this.elementRef.nativeElement.querySelector('div.toggle-help');
-                const auto = toggleDiv.querySelector('.auto');
-                if (auto) {
+                if (this.cardSize === 'auto') {
+                    const toggleDiv = this.elementRef.nativeElement.querySelector('div.toggle-help');
                     const offset = toggleDiv.querySelector('.card').getBoundingClientRect().top + 40;
                     toggleDiv.querySelector('div.card-body').style.height = `calc(100vh - ${offset}px)`;
                 }

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -4,9 +4,9 @@ import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core
     selector: 'plex-help',
     template: `
     <plex-button class="btn-close" *ngIf="!closed" type="danger" [size]="size" icon="close" (click)="toggle();$event.stopImmediatePropagation();"></plex-button>
-    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" type="info" [size]="size" [icon]="icon" (click)="toggle();$event.stopImmediatePropagation();">
+    <plex-button class="btn-open" *ngIf="content && closed && !tituloBoton" [type]="btnType" [size]="size" [icon]="icon" (click)="toggle();$event.stopImmediatePropagation();">
     </plex-button>
-    <plex-button class="btn-open" *ngIf="content && closed && tituloBoton" type="info" [size]="size" [label]="tituloBoton" (click)="toggle();$event.stopImmediatePropagation();">
+    <plex-button class="btn-open" *ngIf="content && closed && tituloBoton" [type]="btnType" [size]="size" [label]="tituloBoton" (click)="toggle();$event.stopImmediatePropagation();">
     </plex-button>
     <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}">
         <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
@@ -35,6 +35,8 @@ export class PlexHelpComponent {
     @Input() title: string;
 
     @Input() type: 'info' | 'help' = 'help'; // deprecated
+
+    @Input() btnType: PlexType = 'info';
 
     @Input() tituloBoton = '';
 

--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core';
+import { PlexType } from './../core/plex-type.type';
+import { Component, Input, Renderer2, Output, EventEmitter, ElementRef } from '@angular/core';
 
 @Component({
     selector: 'plex-help',
@@ -8,8 +9,8 @@ import { Component, Input, Renderer2, Output, EventEmitter } from '@angular/core
     </plex-button>
     <plex-button class="btn-open" *ngIf="content && closed && tituloBoton" [type]="btnType" [size]="size" [label]="tituloBoton" (click)="toggle();$event.stopImmediatePropagation();">
     </plex-button>
-    <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}">
-        <div class="card help" [ngClass]="{'open': !closed, 'full': cardSize === 'full', 'half': cardSize === 'half'}" (click)="$event.stopImmediatePropagation();">
+    <div class="toggle-help" [ngClass]="{'closed': closed, 'open': !closed}" #plHelpBody>
+        <div class="card help" [class.open]="!closed" [class.closed]="closed" [ngClass]="cardSize" (click)="$event.stopImmediatePropagation();">
             <ng-container *ngIf="!closed">
                 <div class="card-body m-3">
                     <plex-title *ngIf="titulo" size="sm" [titulo]="titulo"></plex-title>
@@ -30,7 +31,7 @@ export class PlexHelpComponent {
 
     @Input() size: 'sm' | 'md' = 'sm';
 
-    @Input() cardSize: 'full' | 'half' = 'full';
+    @Input() cardSize: 'full' | 'half' | 'auto' = 'full';
 
     @Input() title: string;
 
@@ -50,16 +51,27 @@ export class PlexHelpComponent {
 
     closed = true;
 
-    constructor(private renderer: Renderer2) { }
+    constructor(
+        private elementRef: ElementRef,
+        private renderer: Renderer2
+    ) { }
 
     get content() {
         return (this.icon && this.icon.length > 0) || (this.tituloBoton && this.tituloBoton.length > 0);
     }
 
     public toggle() {
-
         this.closed = !this.closed;
         if (!this.closed) {
+
+            setTimeout(() => {
+                const toggleDiv = this.elementRef.nativeElement.querySelector('div.toggle-help');
+                const auto = toggleDiv.querySelector('.auto');
+                if (auto) {
+                    const offset = toggleDiv.querySelector('.card').getBoundingClientRect().top + 40;
+                    toggleDiv.querySelector('div.card-body').style.height = `calc(100vh - ${offset}px)`;
+                }
+            }, 0);
 
             this.open.emit();
             this.unlisten = this.renderer.listen('document', 'click', (event) => {


### PR DESCRIPTION
- `<plex-help cardSize="auto" ...>` no genera un scroll, se adapta al alto de la pantalla
- `<plex-help [btnType]="PlexType" ...>` permite usar colores de botón help según la paleta Andes