### PR TITLE
PLEX-309: Navegación hacia atrás en plex-title

### DIFF
--- a/src/demo/app/home/home.component.ts
+++ b/src/demo/app/home/home.component.ts
@@ -50,4 +50,8 @@ export class HomeDemoComponent implements OnInit {
 
     helpClick() {
     }
+
+    back() {
+        alert('Navegando...');
+    }
 }

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -1,10 +1,11 @@
 <plex-layout main="8">
   <plex-layout-main>
-    <plex-title main justify titulo="Gestor de agendas">
+    <plex-title main justify titulo="Gestor de agendas" [backNav]="back">
       <plex-badge size="sm" type="success">VALIDADO
       </plex-badge>
       <plex-help icon="information" titulo="Información sobre este módulo"
-                 subtitulo="A continuación todas las opciones">
+        subtitulo="A continuación todas las opciones">
+
         <ol info class="list-group-flush">
           <li class="list-group-item">Buscá conceptos SNOMED en el campo de texto del panel lateral
             (acepta búsquedas
@@ -15,7 +16,7 @@
           <li class="list-group-item">Opcionalmente podés elegir seleccionar a todos los descendientes
             del concepto.</li>
           <li class="list-group-item">Hacé click en "Guardar todos" o el botón con el signo <plex-icon type="default"
-                       size="md" name="check"></plex-icon> para guardar una plantilla
+              size="md" name="check"></plex-icon> para guardar una plantilla
             individual</li>
         </ol>
       </plex-help>
@@ -127,7 +128,7 @@
         </ul>
       </plex-help>
       <plex-button size="sm" type="{{ plex.navbarVisible ? 'danger' : 'success' }}"
-                   icon="{{ plex.navbarVisible ? 'close' : 'eye' }}" (click)="plex.toggleHideNavBar()">
+        icon="{{ plex.navbarVisible ? 'close' : 'eye' }}" (click)="plex.toggleHideNavBar()">
       </plex-button>
     </plex-title>
     <plex-detail size="sm">
@@ -241,7 +242,7 @@
     <form #form="ngForm">
       <p>El siguiente ejemplo muestra el uso de la propiedad <strong>validateForm</strong></p>
       <plex-text label="Este es un campo de texto requerido" name="campo1" [(ngModel)]="field" [disabled]="false"
-                 required>
+        required>
       </plex-text>
       <plex-button label="Guardar formulario" validateForm="true" (click)="guardar($event)">
       </plex-button>

--- a/src/demo/app/home/home.html
+++ b/src/demo/app/home/home.html
@@ -1,6 +1,6 @@
 <plex-layout main="8">
   <plex-layout-main>
-    <plex-title main justify titulo="Gestor de agendas" [backNav]="back">
+    <plex-title main justify titulo="Gestor de agendas" (back)="back()">
       <plex-badge size="sm" type="success">VALIDADO
       </plex-badge>
       <plex-help icon="information" titulo="Información sobre este módulo"

--- a/src/lib/title/title.component.ts
+++ b/src/lib/title/title.component.ts
@@ -1,15 +1,15 @@
 import { PlexType } from './../core/plex-type.type';
-import { Component, Input } from '@angular/core';
+import { Component, Input, EventEmitter, Output, OnInit } from '@angular/core';
 
 @Component({
     selector: 'plex-title',
     template: `
         <div role="heading" [attr.aria-level]="ariaLevel" class="plex-title d-flex flex-row justify-content-between align-items-center" responsive>
             <div class="nav-title" justify="start">
-                <span *ngIf="backNav" class="hover">
-                    <plex-icon name="flecha-izquierda" size="lg" type="info" (click)="backNav()"></plex-icon>
+                <span *ngIf="hasBackButton" class="hover mr-2" (click)="onBack()">
+                    <plex-icon name="flecha-izquierda" size="lg" type="info" ></plex-icon>
                 </span>
-                <div class="plex-title-label {{ size }} {{ cssType }} ml-2"> {{ titulo }} </div>
+                <div class="plex-title-label {{ size }} {{ cssType }}"> {{ titulo }} </div>
             </div>
             <div class="title-content">
                 <ng-content></ng-content>
@@ -21,11 +21,13 @@ import { Component, Input } from '@angular/core';
         </div>
     `
 })
-export class PlexTitleComponent {
+export class PlexTitleComponent implements OnInit {
     @Input() titulo: string;
     @Input() size: 'sm' | 'md' | 'xl' | 'lg' = 'lg';
     @Input() type: PlexType = 'info';
-    @Input() backNav: Function;
+    @Output() back = new EventEmitter();
+
+    hasBackButton = false;
 
     // Asigna un aria-level al heading según su tamaño
     get ariaLevel() {
@@ -38,5 +40,13 @@ export class PlexTitleComponent {
 
     constructor() {
 
+    }
+
+    ngOnInit() {
+        this.hasBackButton = this.back.observers.length > 0;
+    }
+
+    onBack() {
+        this.back.emit();
     }
 }

--- a/src/lib/title/title.component.ts
+++ b/src/lib/title/title.component.ts
@@ -5,7 +5,12 @@ import { Component, Input } from '@angular/core';
     selector: 'plex-title',
     template: `
         <div role="heading" [attr.aria-level]="ariaLevel" class="plex-title d-flex flex-row justify-content-between align-items-center" responsive>
-            <div class="plex-title-label {{ size }} {{cssType}}"> {{ titulo }} </div>
+            <div class="nav-title" justify="start">
+                <span *ngIf="backNav" class="hover">
+                    <plex-icon name="flecha-izquierda" size="lg" type="info" (click)="backNav()"></plex-icon>
+                </span>
+                <div class="plex-title-label {{ size }} {{ cssType }} ml-2"> {{ titulo }} </div>
+            </div>
             <div class="title-content">
                 <ng-content></ng-content>
             </div>
@@ -20,6 +25,7 @@ export class PlexTitleComponent {
     @Input() titulo: string;
     @Input() size: 'sm' | 'md' | 'xl' | 'lg' = 'lg';
     @Input() type: PlexType = 'info';
+    @Input() backNav: Function;
 
     // Asigna un aria-level al heading según su tamaño
     get ariaLevel() {

--- a/src/lib/title/title.component.ts
+++ b/src/lib/title/title.component.ts
@@ -7,7 +7,7 @@ import { Component, Input, EventEmitter, Output, OnInit } from '@angular/core';
         <div role="heading" [attr.aria-level]="ariaLevel" class="plex-title d-flex flex-row justify-content-between align-items-center" responsive>
             <div class="nav-title" justify="start">
                 <span *ngIf="hasBackButton" class="hover mr-2" (click)="onBack()">
-                    <plex-icon name="flecha-izquierda" size="lg" type="info" ></plex-icon>
+                    <plex-icon name="flecha-izquierda" size="lg" type="info"></plex-icon>
                 </span>
                 <div class="plex-title-label {{ size }} {{ cssType }}"> {{ titulo }} </div>
             </div>


### PR DESCRIPTION
Implementa navegación hacia atrás en `plex-title`.
Funciona usando un Output `back`, por ejemplo: 
```html
<plex-title main justify titulo="Gestor de agendas" (back)="back()"> ... </plex-title>
```
```typescript
public back() {
    // ir atrás
}
```