### PR TITLE
Datos extra en plex-select

### DIFF
--- a/src/demo/app/select/select.component.ts
+++ b/src/demo/app/select/select.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { map, tap } from 'rxjs/operators';
 import { SelectEvent } from './../../../lib/select/select-event.interface';
 import { ServiceDemoSelect } from './select.service';
 
@@ -46,7 +47,13 @@ export class SelectDemoComponent implements OnInit {
 
     loadData(event: SelectEvent) {
         if (event.query) {
-            this.servicio.get(event.query).subscribe(event.callback);
+            this.servicio.get(event.query)
+                .pipe(
+                    map(arrayPaises => arrayPaises.map(pais => ({ ...pais, ...{ extra: `<em>ID: [${pais.id.toUpperCase()}]</em>` } }))),
+                    // tslint:disable-next-line:no-console
+                    tap(console.log)
+                )
+                .subscribe(event.callback);
         } else {
             event.callback(null);
         }

--- a/src/demo/app/select/select.component.ts
+++ b/src/demo/app/select/select.component.ts
@@ -49,7 +49,7 @@ export class SelectDemoComponent implements OnInit {
         if (event.query) {
             this.servicio.get(event.query)
                 .pipe(
-                    map(arrayPaises => arrayPaises.map(pais => ({ ...pais, ...{ extra: `<em>ID: [${pais.id.toUpperCase()}]</em>` } }))),
+                    map(arrayPaises => arrayPaises.map(pais => ({ ...pais, ...{ extra: `<em>ID: [${pais.id.toString().toUpperCase()}]</em>` } }))),
                     // tslint:disable-next-line:no-console
                     tap(console.log)
                 )

--- a/src/demo/app/select/select.html
+++ b/src/demo/app/select/select.html
@@ -12,18 +12,19 @@
                     <plex-bool type="slide" label="Select requerido" name="req" [(ngModel)]="modelo2.required">
                     </plex-bool>
                     <plex-select [(ngModel)]="modelo2.select" name="select1" (getData)="loadData($event)"
-                                 label="Select estático" [required]="modelo2.required">
+                        label="Select estático" [required]="modelo2.required">
                     </plex-select>
                     <plex-select [(ngModel)]="modelo2.selectMultiple" [multiple]="true" name="selectmultiple"
-                                 (getData)="loadData($event)" label="Múltiple con llamada a la API"
-                                 [readonly]="modelo2.soloLectura" placeholder="Ingrese un país">
+                        (getData)="loadData($event)" label="Múltiple con llamada a la API"
+                        [readonly]="modelo2.soloLectura" placeholder="Ingrese un país" labelField="nombre"
+                        [extraFields]="['nombre']">
                     </plex-select>
                     <plex-bool [(ngModel)]="modelo2.soloLectura" name="soloLectura" label="Sólo lectura">
                     </plex-bool>
 
                     <plex-select [(ngModel)]="modelo2.selectMultiple" [multiple]="true" name="selectmultiple-2"
-                                 (getData)="loadData($event)" label="plex-select disabled" [disabled]="true"
-                                 required="true" placeholder="deshabilitado">
+                        (getData)="loadData($event)" label="plex-select disabled" [disabled]="true" required="true"
+                        placeholder="deshabilitado">
                     </plex-select>
 
                 </form>
@@ -36,7 +37,7 @@
         <div class="row">
             <div class="col-md-6">
                 <plex-select [(ngModel)]="modelo1.select" [data]="opciones"
-                             label-field="nombre + ' (' + continente + ')'" label="Seleccione un país">
+                    label-field="nombre + ' (' + continente + ')'" label="Seleccione un país">
                 </plex-select>
             </div>
             <div class="col-md-6">

--- a/src/demo/app/select/select.html
+++ b/src/demo/app/select/select.html
@@ -17,7 +17,7 @@
                     <plex-select [(ngModel)]="modelo2.selectMultiple" [multiple]="true" name="selectmultiple"
                         (getData)="loadData($event)" label="Múltiple con llamada a la API"
                         [readonly]="modelo2.soloLectura" placeholder="Ingrese un país" labelField="nombre"
-                        [extraFields]="['nombre']">
+                        [extraFields]="['extra']">
                     </plex-select>
                     <plex-bool [(ngModel)]="modelo2.soloLectura" name="soloLectura" label="Sólo lectura">
                     </plex-bool>

--- a/src/lib/select/select.component.ts
+++ b/src/lib/select/select.component.ts
@@ -298,10 +298,12 @@ export class PlexSelectComponent implements AfterViewInit, ControlValueAccessor 
                 // Busca en la lista de items un valor que coincida con la clave
                 if (this.multiple) {
                     let result = [];
-                    for (let i = 0; i < this.data.length; i++) {
-                        // value es siempre un string, por eso es necesario convertir el id
-                        if (value.indexOf('' + this.data[i][this.idField]) >= 0) {
-                            result = [...result, this.data[i]];
+                    if (this.data && this.data.length) {
+                        for (let i = 0; i < this.data.length; i++) {
+                            // value es siempre un string, por eso es necesario convertir el id
+                            if (value.indexOf('' + this.data[i][this.idField]) >= 0) {
+                                result = [...result, this.data[i]];
+                            }
                         }
                     }
                     this.value = result.length ? result : null;

--- a/src/lib/select/select.component.ts
+++ b/src/lib/select/select.component.ts
@@ -217,7 +217,7 @@ export class PlexSelectComponent implements AfterViewInit, ControlValueAccessor 
         }
         let extras = '';
         if (this.extraFields.length) {
-            for (let i in this.extraFields) {
+            for (const i in this.extraFields) {
                 extras += this.renderField(this.extraFields[i], item);
             }
         }

--- a/src/lib/select/select.component.ts
+++ b/src/lib/select/select.component.ts
@@ -3,7 +3,6 @@ import { ControlValueAccessor, NgControl, } from '@angular/forms';
 import { SelectEvent } from './select-event.interface';
 import { hasRequiredValidator } from '../core/validator.functions';
 
-// Importo las librerías
 const Selectize = require('selectize/dist/js/standalone/selectize');
 
 @Component({
@@ -201,7 +200,7 @@ export class PlexSelectComponent implements AfterViewInit, ControlValueAccessor 
             result += field.slice(1, field.length - 1) + ' ';
         } else {
             if (field.indexOf('.') < 0) {
-                result += item[field] + ' ';
+                result += item[field] || '' + ' ';
             } else {
                 const prefix = field.substring(0, field.indexOf('.'));
                 const suffix = field.slice(field.indexOf('.') + 1);
@@ -218,7 +217,7 @@ export class PlexSelectComponent implements AfterViewInit, ControlValueAccessor 
         let extras = '';
         if (this.extraFields.length) {
             for (const i in this.extraFields) {
-                extras += this.renderField(this.extraFields[i], item);
+                extras += `${this.renderField(this.extraFields[i], item)} `;
             }
         }
         return extras;


### PR DESCRIPTION
- Implementa un `@Input` que acepta un array de strings indicando qué datos del set que usa el `plex-select` se quieren mostrar como datos extra.
### Ejemplo: 
- dataset: 
```typescript
[{
    id: 1,
    nombre: 'PEDRO',
    apellido: 'PEREZ',
    documento: '123456789'
}]
```
- uso HTML: 
```html
<plex-select [(ngModel)]="modelo2.selectMultiple" [multiple]="true" name="selectmultiple"
                        (getData)="loadData($event)" label="Múltiple con llamada a la API"
                        [readonly]="modelo2.soloLectura" placeholder="Ingrese un país" labelField="nombre+' '+apellido"
                        [extraFields]="['documento']">
                    </plex-select>
```

https://user-images.githubusercontent.com/11394455/146250894-2a7f2912-412d-4253-aed0-fb7eb2db78b4.mov

