### PR TITLE
PLEX-TEXT - agrega rows en plex-text multiline

### DIFF
--- a/src/lib/text/text.component.ts
+++ b/src/lib/text/text.component.ts
@@ -33,7 +33,7 @@ import { hasRequiredValidator } from '../core/validator.functions';
         </div>
 
         <!-- Multiline -->
-        <textarea [attr.aria-label]="textLabel" [attr.aria-labelledby]="passwordLabel" [attr.aria-hidden]="!multiline || html" [hidden]="!multiline || html" #textarea class="form-control" [placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly"
+        <textarea [attr.aria-label]="textLabel" [attr.aria-labelledby]="passwordLabel" [attr.aria-hidden]="!multiline || html" [hidden]="!multiline || html" #textarea class="form-control" [placeholder]="placeholder" [rows]="rows" [disabled]="disabled" [readonly]="readonly"
         (input)="onChange($event.target.value)" (change)="disabledEvent($event)" (focus)="onFocus()" (focusout)="onFocusout()">
         </textarea>
 
@@ -87,6 +87,7 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
     @Input() disabled = false;
     @Input() readonly = false;
     @Input() multiline = false;
+    @Input() rows: number;
     @Input() html = false;
     @Input() debounce = 0;
     @Input() qlToolbar: PlexTextToolBar[];
@@ -242,9 +243,8 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
      * @memberof PlexTextComponent
      */
     adjustTextArea() {
-        this.textarea.nativeElement.style.overflow = 'hidden';
-        this.textarea.nativeElement.style.height = 'auto';
-        this.textarea.nativeElement.style.height = this.textarea.nativeElement.scrollHeight + 'px';
+        this.textarea.nativeElement.style.overflow = 'auto';
+        this.textarea.nativeElement.style.height = (this.rows) ? this.rows + 'em' : '4em';
     }
 
 


### PR DESCRIPTION
https://proyectos.andes.gob.ar/browse/PLEX-129

- Se puede agregar en los plex-text con multiline="true" el atributo **rows** para darle una altura fija. El valor en rows es guardado se toma con la unidad de medida em (Por ejemplo, rows="5" son 5em) -> **1em = 16px**
- Si no posee el atributo rows, por defecto tiene un alto de 4em (64px). 