### PR TITLE
PLEX-GRID - agrega control si existe subtitulo

### DIFF
--- a/src/lib/grid/grid.component.ts
+++ b/src/lib/grid/grid.component.ts
@@ -76,7 +76,7 @@ export class PlexGridComponent implements AfterViewChecked {
         const labelListElement = this.plexLabelsElement.toArray();
         this.plexLabels.forEach((label: PlexLabelComponent, index) => {
             const native: ElementRef = labelListElement[index];
-            if (label.subtitulo.length > 28) {
+            if (label.subtitulo?.length > 28) {
                 this.render.setStyle(native.nativeElement, 'grid-column-end', 'span 2');
             } else {
                 this.render.setStyle(native.nativeElement, 'grid-column-end', 'unset');


### PR DESCRIPTION
**Requerimiento**
https://proyectos.andes.gob.ar/browse/PLEX-321

**Funcionalidad desarrollada**
1. En plex-grid se controla la cantidad de caracteres para acomodar el texto, y cuando preguntaba por el .length y no tenia subtitulo el plex-label se rompía, asi que se agregó un control antes de preguntar por el .length

