### PR TITLE
PLEX -  Evitar aperturas de plex-help simultáneas

### DIFF
--- a/src/lib/help/help.component.ts
+++ b/src/lib/help/help.component.ts
@@ -1,5 +1,6 @@
-import { Component, ElementRef, EventEmitter, HostListener, Input, OnInit, Output, Renderer2 } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2 } from '@angular/core';
 import { PlexType } from './../core/plex-type.type';
+import { HelpService } from './services/help.service';
 
 @Component({
     selector: 'plex-help',
@@ -22,8 +23,7 @@ import { PlexType } from './../core/plex-type.type';
     </div>
     `
 })
-export class PlexHelpComponent {
-
+export class PlexHelpComponent implements OnInit {
 
     @Input() titulo = '';
 
@@ -51,11 +51,17 @@ export class PlexHelpComponent {
 
     closed = true;
     parentElement;
+    id;
 
     constructor(
         private elementRef: ElementRef,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private helpService: HelpService,
     ) { }
+
+    ngOnInit(): void {
+        this.id = Math.floor(Math.random() * 1000);
+    }
 
     get content() {
         return (this.icon && this.icon.length > 0) || (this.tituloBoton && this.tituloBoton.length > 0);
@@ -67,9 +73,12 @@ export class PlexHelpComponent {
     }
 
     public toggle() {
-        this.closed = !this.closed;
+        this.helpService.closePreviuos(this.id);
 
+        this.closed = !this.closed;
         if (!this.closed) {
+            this.helpService.setHelp(this);
+
             setTimeout(() => {
                 const offset = this.elementRef.nativeElement.getBoundingClientRect().top;
                 const card = this.elementRef.nativeElement.querySelector('.card.open');
@@ -93,6 +102,8 @@ export class PlexHelpComponent {
         } else {
             this.toggleClose();
 
+            this.close.emit();
+            this.helpService.setHelp(null);
             if (this.unlisten) {
                 this.unlisten();
             }

--- a/src/lib/help/services/help.service.ts
+++ b/src/lib/help/services/help.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable()
+export class HelpService {
+
+    private helpCache = new BehaviorSubject<any>(null);
+
+    setHelp(help: any) {
+        this.helpCache.next(help);
+    }
+
+    closePreviuos(id: number) {
+        const help = this.helpCache.value;
+
+        if (help && help.id !== id) {
+            help.toggleClose();
+            this.helpCache.next(null);
+        }
+    }
+}

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -76,6 +76,7 @@ import { NavItemComponent } from './app/nav-item.component';
 import { HintComponent } from './hint/hint.component';
 import { HintDirective } from './hint/hint.directive';
 import { HelpDirective } from './help/help.directive';
+import { HelpService } from './help/services/help.service';
 import { TabDirective } from './tabs/pl-tab.directive';
 import { Plex } from './core/service';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
@@ -251,6 +252,7 @@ import { PlexVisualizadorService } from './core/plex-visualizador.service';
     ],
     providers: [
         TitleCasePipe,
+        HelpService,
     ]
 
 })


### PR DESCRIPTION
Requerimiento
https://proyectos.andes.gob.ar/browse/PLEX-323

Funcionalidad desarrollada

1. Se implementa una cache de datos para mantener una única instancia de plex-help abierta. Se controla mediante un id autogenerado si el plex-help que se abre es el actual o uno nuevo.