### PR TITLE
PLEX-BOOL - Corregir overflow en checkbox

### DIFF
--- a/src/lib/css/plex-bool.scss
+++ b/src/lib/css/plex-bool.scss
@@ -30,6 +30,7 @@ plex-bool {
 }
 
 .mat-checkbox-inner-container {
+    overflow: unset !important;
     margin: unset !important;
 }
 


### PR DESCRIPTION
Requerimiento
https://proyectos.andes.gob.ar/browse/PLEX-342

Funcionalidad desarrollada

1. Modifica estilos en plex-bool para quitar overflow en checkbox