### PR TITLE
PLEX-TEXT - Repara error de vista html en plex-text

### DIFF
--- a/src/lib/text/text.component.ts
+++ b/src/lib/text/text.component.ts
@@ -180,9 +180,10 @@ export class PlexTextComponent implements OnInit, AfterViewInit, ControlValueAcc
         } else {
             if (this.html) {
                 const component = (this.quillEditor as any);
-                // Por el dinamismo de RUP hay una primera instancia que quillEditor es undefined
+
                 if (component.quillEditor) {
-                    component.quillEditor.setContents(component.valueSetter(component.quillEditor, typeof value === 'undefined' ? '' : value));
+                    const formattedValue = value.replace(/<\/p><p>/g, '</p><p><br></p>');
+                    component.quillEditor.clipboard.dangerouslyPasteHTML(formattedValue);
                 }
             }
         }


### PR DESCRIPTION
Requerimiento
https://proyectos.andes.gob.ar/browse/PLEX-348

Funcionalidad desarrollada

Implementa fix para evitar borrado de saltos de línea luego de cargar contenido HTML a plex-text